### PR TITLE
Update `src/nanotron/config/config.py`

### DIFF
--- a/examples/config_tiny_llama.py
+++ b/examples/config_tiny_llama.py
@@ -97,6 +97,7 @@ config = Config(
     logging=LoggingArgs(),
     tokens=tokens,
     data=DataArgs(dataset=dataset, seed=seed),
+    profiler=None,
 )
 
 if __name__ == "__main__":

--- a/examples/config_tiny_llama.py
+++ b/examples/config_tiny_llama.py
@@ -97,7 +97,6 @@ config = Config(
     logging=LoggingArgs(),
     tokens=tokens,
     data=DataArgs(dataset=dataset, seed=seed),
-    profiler=None,
 )
 
 if __name__ == "__main__":

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -331,7 +331,7 @@ class Config:
     tokens: TokensArgs
     optimizer: OptimizerArgs
     data: DataArgs
-    profiler: Optional[ProfilerArgs]
+    profiler: Optional[ProfilerArgs] = None
 
     def __post_init__(self):
         # Some final sanity checks across separate arguments sections:

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -331,7 +331,7 @@ class Config:
     tokens: TokensArgs
     optimizer: OptimizerArgs
     data: DataArgs
-    profiler: Optional[ProfilerArgs] = None
+    profiler: Optional[ProfilerArgs]
 
     def __post_init__(self):
         # Some final sanity checks across separate arguments sections:


### PR DESCRIPTION
I was getting `TypeError: Config.__init__() missing 1 required positional argument: profiler'` when trying to run `examples/config_tiny_llama.py`.


Explicitly:

```bash
$ python3 examples/config_tiny_llama.py
Model has 16p4K parameters
Traceback (most recent call last):
  File "/lus/grand/projects/datascience/foremans/locations/polaris/projects/saforem2/nanotron/examples/config_tiny_llama.py", line 90, in <module>
    config = Config(
TypeError: Config.__init__() missing 1 required positional argument: 'profiler'
[1]    30778 exit 1     python3 examples/config_tiny_llama.py
2.78s user 5.53s system 231% cpu 3.590s total
```

the issue is coming from this line in the `Config` object in `src/nanotron/config/config.py`:

https://github.com/huggingface/nanotron/blob/main/src/nanotron/config/config.py#L334

Setting the `Optional[ProfilerArgs] = None` by default (as shown below) fixes this:

```python
@dataclass
class Config:
    # [...]
    profiler: Optional[ProfilerArgs] = None
```

