### PR TITLE
[Feature] Add loading different datasets based on training stages

### DIFF
--- a/examples/config_tiny_llama.yaml
+++ b/examples/config_tiny_llama.yaml
@@ -1,19 +1,36 @@
 checkpoints:
   checkpoint_interval: 10
-  checkpoints_path: /fsx/nouamane/projects/nanotron/checkpoints
+  checkpoints_path: checkpoints
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: null
   save_initial_state: false
-data:
-  dataset:
-    dataset_overwrite_cache: false
-    dataset_processing_num_proc_per_process: 1
-    hf_dataset_config_name: null
-    hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
-    hf_dataset_splits: train
-    text_column_name: completion
-  num_loading_workers: 1
-  seed: 42
+
+data_stages:
+  - name: Stable Training Stage
+    start_training_step: 1
+    data:
+      dataset:
+        dataset_overwrite_cache: false
+        dataset_processing_num_proc_per_process: 1
+        hf_dataset_config_name: null
+        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
+        hf_dataset_splits: train
+        text_column_name: completion
+      num_loading_workers: 1
+      seed: 42
+  - name: Annealing Phase
+    start_training_step: 10
+    data:
+      dataset:
+        dataset_overwrite_cache: false
+        dataset_processing_num_proc_per_process: 1
+        hf_dataset_config_name: null
+        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
+        hf_dataset_splits: train
+        text_column_name: completion
+      num_loading_workers: 1
+      seed: 42
+
 general:
   benchmark_csv_path: null
   consumed_train_samples: null
@@ -87,5 +104,5 @@ tokens:
   limit_val_batches: 0
   micro_batch_size: 2
   sequence_length: 32
-  train_steps: 10
+  train_steps: 20
   val_check_interval: -1

--- a/examples/contributor-guide/debug_config_tiny_llama.yaml
+++ b/examples/contributor-guide/debug_config_tiny_llama.yaml
@@ -4,16 +4,20 @@ checkpoints:
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: null
   save_initial_state: false
-data:
-  dataset:
-    dataset_overwrite_cache: false
-    dataset_processing_num_proc_per_process: 1
-    hf_dataset_config_name: null
-    hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
-    hf_dataset_splits: train
-    text_column_name: completion
-  num_loading_workers: 1
-  seed: 42
+
+data_stages:
+  - name: General purpose training
+    start_training_step: 1
+    data:
+      dataset:
+        dataset_overwrite_cache: false
+        dataset_processing_num_proc_per_process: 1
+        hf_dataset_config_name: null
+        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
+        hf_dataset_splits: train
+        text_column_name: completion
+      num_loading_workers: 1
+      seed: 42
 general:
   benchmark_csv_path: null
   consumed_train_samples: null

--- a/examples/mamba/config_mamba.yaml
+++ b/examples/mamba/config_mamba.yaml
@@ -4,17 +4,21 @@ checkpoints:
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: null
   save_initial_state: false
-data:
-  dataset:
-    dataset_overwrite_cache: false
-    dataset_processing_num_proc_per_process: 24
-    hf_dataset_config_name: null
-    hf_dataset_or_datasets:
-      roneneldan/TinyStories: 1.0
-    hf_dataset_splits: train
-    text_column_name: text
-  num_loading_workers: 1
-  seed: 42
+
+data_stages:
+  - name: General purpose training
+    start_training_step: 1
+    data:
+      dataset:
+        dataset_overwrite_cache: false
+        dataset_processing_num_proc_per_process: 24
+        hf_dataset_config_name: null
+        hf_dataset_or_datasets:
+          roneneldan/TinyStories: 1.0
+        hf_dataset_splits: train
+        text_column_name: text
+      num_loading_workers: 1
+      seed: 42
 general:
   benchmark_csv_path: null
   consumed_train_samples: null

--- a/examples/moe/config_llamoe.yaml
+++ b/examples/moe/config_llamoe.yaml
@@ -4,16 +4,19 @@ checkpoints:
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: /fsx/nouamane/projects/nanotron/examples/checkpoints
   save_initial_state: true
-data:
-  dataset:
-    dataset_overwrite_cache: false
-    dataset_processing_num_proc_per_process: 12
-    hf_dataset_config_name: null
-    hf_dataset_or_datasets: roneneldan/TinyStories
-    hf_dataset_splits: train
-    text_column_name: text
-  num_loading_workers: 1
-  seed: 42
+data_stages:
+  - name: General purpose training
+    start_training_step: 1
+    data:
+      dataset:
+        dataset_overwrite_cache: false
+        dataset_processing_num_proc_per_process: 12
+        hf_dataset_config_name: null
+        hf_dataset_or_datasets: roneneldan/TinyStories
+        hf_dataset_splits: train
+        text_column_name: text
+      num_loading_workers: 1
+      seed: 42
 general:
   benchmark_csv_path: null
   consumed_train_samples: null

--- a/run_train.py
+++ b/run_train.py
@@ -8,9 +8,12 @@ torchrun --nproc_per_node=8 run_train.py --config-file examples/config_tiny_llam
 ```
 """
 import argparse
+from typing import Dict, cast
 
 from nanotron import logging
 from nanotron.config import (
+    DataArgs,
+    DatasetStageArgs,
     PretrainDatasetsArgs,
 )
 from nanotron.dataloader import (
@@ -25,6 +28,7 @@ from nanotron.trainer import DistributedTrainer
 from nanotron.utils import (
     main_rank_first,
 )
+from torch.utils.data import DataLoader
 
 try:
     from huggingface_hub import __version__ as hf_hub_version
@@ -37,14 +41,14 @@ except ImportError:
 logger = logging.get_logger(__name__)
 
 
-def get_dataloader(trainer: DistributedTrainer):
+def get_dataloader_from_data_stage(trainer: DistributedTrainer, data: DataArgs):
     """Returns a dataloader for training."""
 
     # First, we need to know which ranks to feed the dataloader to
     input_pp_rank, output_pp_rank = get_input_output_pp_ranks(model=trainer.model)
 
     # Case 1: Dummy data generator
-    if trainer.config.data.dataset is None:
+    if data.dataset is None:
         log_rank("Using dummy data generator", logger=logger, level=logging.INFO, rank=0)
         dataloader = dummy_infinite_data_generator(
             micro_batch_size=trainer.micro_batch_size,
@@ -52,12 +56,12 @@ def get_dataloader(trainer: DistributedTrainer):
             input_pp_rank=input_pp_rank,
             output_pp_rank=output_pp_rank,
             vocab_size=trainer.model_config.vocab_size,
-            seed=trainer.config.data.seed,
+            seed=data.seed,
             parallel_context=trainer.parallel_context,
         )()
 
     # Case 2: HuggingFace datasets
-    elif isinstance(trainer.config.data.dataset, PretrainDatasetsArgs):
+    elif isinstance(data.dataset, PretrainDatasetsArgs):
         log_rank("Using `datasets` library", logger=logger, level=logging.INFO, rank=0)
         tokenizer_path = trainer.config.tokenizer.tokenizer_name_or_path
         log_rank(
@@ -74,8 +78,8 @@ def get_dataloader(trainer: DistributedTrainer):
 
             # We load the raw dataset
             raw_dataset = get_datasets(
-                hf_dataset_or_datasets=trainer.config.data.dataset.hf_dataset_or_datasets,
-                splits=trainer.config.data.dataset.hf_dataset_splits,
+                hf_dataset_or_datasets=data.dataset.hf_dataset_or_datasets,
+                splits=data.dataset.hf_dataset_splits,
             )["train"]
 
             tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
@@ -86,9 +90,9 @@ def get_dataloader(trainer: DistributedTrainer):
             train_dataset = clm_process(
                 raw_dataset=raw_dataset,
                 tokenizer=tokenizer,
-                text_column_name=trainer.config.data.dataset.text_column_name,
-                dataset_processing_num_proc_per_process=trainer.config.data.dataset.dataset_processing_num_proc_per_process,
-                dataset_overwrite_cache=trainer.config.data.dataset.dataset_overwrite_cache,
+                text_column_name=data.dataset.text_column_name,
+                dataset_processing_num_proc_per_process=data.dataset.dataset_processing_num_proc_per_process,
+                dataset_overwrite_cache=data.dataset.dataset_overwrite_cache,
                 sequence_length=trainer.sequence_length,
             )
 
@@ -101,8 +105,8 @@ def get_dataloader(trainer: DistributedTrainer):
                 output_pp_rank=output_pp_rank,
                 micro_batch_size=trainer.micro_batch_size,
                 consumed_train_samples=trainer.consumed_train_samples,
-                dataloader_num_workers=trainer.config.data.num_loading_workers,
-                seed_worker=trainer.config.data.seed,
+                dataloader_num_workers=data.num_loading_workers,
+                seed_worker=data.seed,
                 dataloader_drop_last=True,
             )
             # Check if we have enough samples for train_steps
@@ -117,9 +121,25 @@ def get_dataloader(trainer: DistributedTrainer):
                 f"Try train_steps<={len(dataloader.dataset) // trainer.global_batch_size + trainer.start_iteration_step}"
             )
     else:
-        raise ValueError(f"Unhandled case of `self.config.data.dataset`. Got: {trainer.config.data.dataset}")
+        raise ValueError(f"Unhandled case of `self.config.data.dataset`. Got: {data.dataset}")
 
     return dataloader
+
+
+def get_dataloader(trainer: DistributedTrainer) -> Dict[str, DataLoader]:
+    sorted_stages = sorted(trainer.config.data_stages, key=lambda stage: stage.start_training_step)
+    dataloaders = {}
+    for idx, stage in enumerate(sorted_stages):
+        # NOTE: we only create the dataloader for the first stage,
+        # then we lazy initialize the dataloader for the other stages
+        stage = cast(DatasetStageArgs, stage)
+        dataloader = (
+            get_dataloader(trainer, stage.data)
+            if idx == 0
+            else lambda stage=stage: get_dataloader_from_data_stage(trainer, stage.data)
+        )
+        dataloaders[stage.name] = dataloader
+    return dataloaders
 
 
 def get_args():

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -2,7 +2,7 @@ import datetime
 import os
 from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Optional, Type, Union
+from typing import List, Optional, Type, Union
 
 import dacite
 import torch
@@ -106,6 +106,19 @@ class DataArgs:
     def __post_init__(self):
         if self.seed is None:
             self.seed = DEFAULT_SEED
+
+
+@dataclass
+class DatasetStageArgs:
+    """Arguments for loading dataset in different stages of the training process"""
+
+    name: str
+    start_training_step: int
+    data: DataArgs
+
+    def __post_init__(self):
+        if self.start_training_step < 0:
+            raise ValueError(f"training_steps should be a positive integer and not {self.start_training_step}")
 
 
 @dataclass
@@ -298,7 +311,7 @@ class Config:
     logging: Optional[LoggingArgs] = None
     tokens: Optional[TokensArgs] = None
     optimizer: Optional[OptimizerArgs] = None
-    data: Optional[DataArgs] = None
+    data_stages: Optional[List[DatasetStageArgs]] = None
     profiler: Optional[ProfilerArgs] = None
     lighteval: Optional[LightEvalConfig] = None
 
@@ -316,6 +329,22 @@ class Config:
             self.optimizer.learning_rate_scheduler.lr_decay_steps = (
                 self.tokens.train_steps - self.optimizer.learning_rate_scheduler.lr_warmup_steps
             )
+
+        if self.data_stages is not None:
+            names = [stage.name for stage in self.data_stages]
+            training_steps = [stage.start_training_step for stage in self.data_stages]
+            assert all(
+                stage.start_training_step == 1 for stage in self.data_stages
+            ), "You must have a training stage starting at 1 in the config's data_stages"
+
+            for stage in self.data_stages:
+                if names.count(stage.name) > 1:
+                    raise ValueError(f"Each stage should have unique names and not {names}")
+
+                if training_steps.count(stage.start_training_step) > 1:
+                    raise ValueError(
+                        f"Each stage should have unique starting training step, please change the starting training step for stage {stage.name}"
+                    )
 
         # # if lighteval, we need tokenizer to be defined
         # if self.checkpoints.lighteval is not None:


### PR DESCRIPTION
Reproduce
- Step 1: Modify your config:


**Use a single dataset for the entire training**
```
data:
  dataset:
      dataset_overwrite_cache: false
      dataset_processing_num_proc_per_process: 1
      hf_dataset_config_name: null
      hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
      hf_dataset_splits: train
      text_column_name: completion
```

**Use different datasets based on training stages**

```
  # NOTE: if you wanna use different datasets for different stages of the training
data_stages:
  - name: Stable Training Stage
    start_training_step: 1
    data:
      dataset:
        dataset_overwrite_cache: false
        dataset_processing_num_proc_per_process: 1
        hf_dataset_config_name: null
        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
        hf_dataset_splits: train
        text_column_name: completion
      num_loading_workers: 1
      seed: 42
  - name: Annealing Phase
    start_training_step: 10
    data:
      dataset:
        dataset_overwrite_cache: false
        dataset_processing_num_proc_per_process: 1
        hf_dataset_config_name: null
        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
        hf_dataset_splits: train
        text_column_name: completion
      num_loading_workers: 1
      seed: 42
```


- Step 2: `CUDA_DEVICE_MAX_CONNECTIONS=1 torchrun --nproc_per_node=8 run_train.py --config-file examples/config_tiny_llama.yaml`