### PR TITLE
[Bug] Resuming training for data stages

### DIFF
--- a/examples/config_tiny_llama.yaml
+++ b/examples/config_tiny_llama.yaml
@@ -52,7 +52,7 @@ optimizer:
 parallelism:
   dp: 2
   expert_parallel_size: 1
-  pp: 2
+  pp: 1
   pp_engine: 1f1b
   tp: 2
   tp_linear_async_communication: true
@@ -77,7 +77,7 @@ data_stages:
         dataset_overwrite_cache: false
         dataset_processing_num_proc_per_process: 1
         hf_dataset_config_name: null
-        hf_dataset_or_datasets: HuggingFaceH4/testing_alpaca_small
+        hf_dataset_or_datasets: HuggingFaceH4/testing_codealpaca_small
         hf_dataset_splits: train
         text_column_name: completion
       num_loading_workers: 1
@@ -99,7 +99,7 @@ checkpoints:
   checkpoint_interval: 10
   checkpoints_path: checkpoints
   checkpoints_path_is_shared_file_system: false
-  resume_checkpoint_path: null
+  resume_checkpoint_path: checkpoints
   save_initial_state: false
 profiler: null
 logging:

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -329,6 +329,7 @@ class Config:
             )
 
         if self.data_stages is not None:
+            self.data_stages = sorted(self.data_stages, key=lambda stage: stage.start_training_step)
             names = [stage.name for stage in self.data_stages]
             training_steps = [stage.start_training_step for stage in self.data_stages]
             assert any(
@@ -343,6 +344,12 @@ class Config:
                     raise ValueError(
                         f"Each stage should have unique starting training step, please change the starting training step for stage {stage.name}"
                     )
+
+            # NOTE: must order the stages by start_training_step from lowest to highest
+            assert all(
+                self.data_stages[i].start_training_step < self.data_stages[i + 1].start_training_step
+                for i in range(len(self.data_stages) - 1)
+            ), "The stages are not sorted by start_training_step in increasing order"
 
         # # if lighteval, we need tokenizer to be defined
         # if self.checkpoints.lighteval is not None:

--- a/src/nanotron/constants.py
+++ b/src/nanotron/constants.py
@@ -2,6 +2,9 @@ import platform
 
 from packaging.version import Version, parse
 
-CHECKPOINT_VERSION = Version("1.2")
+CHECKPOINT_VERSION = Version("1.3")
 
 PY_VERSION = parse(platform.python_version())
+
+
+CHECKPOINT_FILE_NAME = "checkpoint_metadata.json"

--- a/src/nanotron/constants.py
+++ b/src/nanotron/constants.py
@@ -6,5 +6,7 @@ CHECKPOINT_VERSION = Version("1.3")
 
 PY_VERSION = parse(platform.python_version())
 
+#### FOR SERIALIZATION ####
 
 CHECKPOINT_FILE_NAME = "checkpoint_metadata.json"
+MODEL_CONFIG_FILE_NAME = "model_config.json"

--- a/src/nanotron/helpers.py
+++ b/src/nanotron/helpers.py
@@ -19,7 +19,7 @@ from torch.profiler import ProfilerActivity, profile, tensorboard_trace_handler
 
 from nanotron import distributed as dist
 from nanotron import logging
-from nanotron.config import Config, LRSchedulerArgs, OptimizerArgs, ParallelismArgs
+from nanotron.config import Config, DatasetStageArgs, LRSchedulerArgs, OptimizerArgs, ParallelismArgs
 from nanotron.distributed import ProcessGroup
 from nanotron.logging import LogItem, log_rank
 from nanotron.models.base import NanotronModel
@@ -43,6 +43,7 @@ from nanotron.random import (
     get_synced_random_state,
 )
 from nanotron.scaling.parametrization import LearningRateForSP, LearningRateForSpectralMup, ParametrizationMethod
+from nanotron.serialize.metadata import TrainingMetadata
 
 logger = logging.get_logger(__name__)
 
@@ -582,3 +583,32 @@ def log_throughput(
 
     if dist.get_rank(parallel_context.world_pg) == 0:
         write_to_csv(config.general.benchmark_csv_path, table_log, model_tflops, slurm_job_id)
+
+
+def compute_remain_train_steps_of_a_data_stage_from_ckp(
+    stage: DatasetStageArgs, config: Config, metadata: TrainingMetadata
+) -> int:
+    def is_last_stage():
+        sorted_stages = sorted(config.data_stages, key=lambda x: x.start_training_step)
+        return sorted_stages[-1].start_training_step == stage.start_training_step
+
+    def is_resume_from_training():
+        return metadata.last_train_step > 0
+
+    if is_last_stage() is True:
+        total_train_steps = config.tokens.train_steps
+    else:
+        next_stage = next((s for s in config.data_stages if s.start_training_step > stage.start_training_step), None)
+        total_train_steps = next_stage.start_training_step
+    last_train_steps = metadata.last_train_step if is_resume_from_training() else stage.start_training_step
+    return total_train_steps - last_train_steps
+
+
+def get_consumed_train_samples_of_a_data_stage_from_ckp(
+    stage: DatasetStageArgs, metadata: TrainingMetadata
+) -> Optional[int]:
+    start_training_step = stage.start_training_step
+    return next(
+        (s.consumed_train_samples for s in metadata.data_stages if s.start_training_step == start_training_step),
+        None,
+    )

--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -17,7 +17,7 @@ from nanotron.sanity_checks import (
     assert_tensor_synced_across_pg,
     check_optim_state_in_sync,
 )
-from nanotron.serialize.metadata import CheckpointMetadata, load_meta, save_meta
+from nanotron.serialize.metadata import CheckpointMetadata, TrainingMetadata, load_meta, save_meta
 from nanotron.serialize.optimizer import (
     load_lr_scheduler,
     load_optimizer,
@@ -51,16 +51,17 @@ def save(
     optimizer: optim.BaseOptimizer,
     lr_scheduler: torch.optim.lr_scheduler.LRScheduler,
     parallel_context: ParallelContext,
+    training_metadata: TrainingMetadata,
     root_folder: Path,
     should_save_config: bool = True,
     should_save_model: bool = True,
     should_save_optimizer: bool = True,
     should_save_lr_scheduler: bool = True,
-    checkpoint_metadata: dict = None,
     sanity_checks: bool = True,
 ) -> None:
-    if checkpoint_metadata is None:
-        checkpoint_metadata = {}
+    assert isinstance(training_metadata, TrainingMetadata)
+    # if checkpoint_metadata is None:
+    #     checkpoint_metadata = {}
 
     try:
         if should_save_config:
@@ -98,6 +99,7 @@ def save(
         raise e
     try:
         if should_save_lr_scheduler:
+            # assert len(lr_scheduler.lambdas) == optimizer.param_groups
             save_lr_scheduler(
                 lr_scheduler=lr_scheduler,
                 parallel_context=parallel_context,
@@ -112,7 +114,7 @@ def save(
         )
         raise e
 
-    save_meta(root_folder=root_folder, parallel_context=parallel_context, checkpoint_metadata=checkpoint_metadata)
+    save_meta(root_folder=root_folder, parallel_context=parallel_context, training_metadata=training_metadata)
 
     # TODO @thomas21: sanity check, not sure whether that needs to happen at testing or now (depends how much it costs)
     ###

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -370,9 +370,7 @@ class DistributedTrainer:
             stage = cast(DatasetStageArgs, stage)
 
             is_resume_from_training = self.current_dataloader is None and stage_idx_to_resume == stage_idx
-            if (
-                stage.start_training_step == 0 and stage.start_training_step == self.iteration_step
-            ) or is_resume_from_training:
+            if (stage.start_training_step == self.iteration_step) or is_resume_from_training:
                 if self.current_dataloader is not None:
                     prev_stage_name = self.config.data_stages[stage_idx - 1].name
                     prev_dataloader = dataloaders[prev_stage_name]


### PR DESCRIPTION
Step 1: Train up to 15 steps, but only save checkpoint at step 10th `CUDA_DEVICE_MAX_CONNECTIONS=1 torchrun --nproc_per_node=4 run_train.py --config-file examples/config_tiny_llama.yaml`

Step 2: Resume training from step 2, and you should see that the training loss from step 10th to 15th in step 2 is the same as in step 1