### PR TITLE
Checkpoint 1.3 backwards compatibility

### DIFF
--- a/src/nanotron/constants.py
+++ b/src/nanotron/constants.py
@@ -2,7 +2,7 @@ import platform
 
 from packaging.version import Version, parse
 
-CHECKPOINT_VERSION = Version("1.3")
+CHECKPOINT_VERSION = Version("1.4")
 
 PY_VERSION = parse(platform.python_version())
 

--- a/src/nanotron/serialize/utils.py
+++ b/src/nanotron/serialize/utils.py
@@ -37,7 +37,6 @@ def get_path(
     suffix = tensor_name.split(".")
     suffix_path, suffix_name = suffix[:-1], suffix[-1]
 
-    suffix_name = f"{type.value}_{suffix_name}.safetensors"
 
     if exp_tp_pp_rank_and_size:
         # We always show pp_rank and tp_rank if `exp_tp_pp_rank_and_size` is provided
@@ -49,6 +48,8 @@ def get_path(
             )
         else:
             suffix_name = f"{type.value}_{suffix_name}_pp-rank-{pp_rank}-of-{pp_size}_tp-rank-{tp_rank}-of-{tp_size}_exp-rank-{exp_rank}-of-{exp_size}.safetensors"
+    else:
+        suffix_name = f"{type.value}_{suffix_name}.safetensors"
 
     suffix_path.append(suffix_name)
     if prefix is None:

--- a/src/nanotron/serialize/utils.py
+++ b/src/nanotron/serialize/utils.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import torch
+from packaging.version import Version
 
 from nanotron.parallel import ParallelContext
 from nanotron.parallel.parameters import SlicesPair
 from nanotron.serialize.metadata import TensorMetadata
+from nanotron.constants import CHECKPOINT_VERSION
 
 
 class ObjectType(Enum):
@@ -30,32 +32,45 @@ def get_exp_tp_pp_rank_and_size_from(
 def get_path(
     tensor_name: str,
     type: ObjectType,
-    exp_tp_pp_rank_and_size: Tuple[Tuple[int, int], Tuple[int, int]],
+    exp_tp_pp_rank_and_size: Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]],
     is_expert_sharded: bool,
     prefix: Optional[Path] = None,
-) -> List[str]:
+    version: Version = CHECKPOINT_VERSION,
+    return_all_matches: bool = False,
+) -> Path | List[Path]:
     suffix = tensor_name.split(".")
     suffix_path, suffix_name = suffix[:-1], suffix[-1]
 
 
+    if version == Version("1.3"):
+        suffix_name = f"{type.value}_{suffix_name}.safetensors"
     if exp_tp_pp_rank_and_size:
         # We always show pp_rank and tp_rank if `exp_tp_pp_rank_and_size` is provided
         # We only show exp_rank if tensor is exp_sharded and exp_size > 1
         (exp_rank, exp_size), (tp_rank, tp_size), (pp_rank, pp_size) = exp_tp_pp_rank_and_size
         if not is_expert_sharded or exp_size == 1:
+            pattern = f"{type.value}_{suffix_name}*.safetensors"
             suffix_name = (
                 f"{type.value}_{suffix_name}_pp-rank-{pp_rank}-of-{pp_size}_tp-rank-{tp_rank}-of-{tp_size}.safetensors"
             )
         else:
+            pattern = f"{type.value}_{suffix_name}*exp-rank-{exp_rank}-of-{exp_size}.safetensors"
             suffix_name = f"{type.value}_{suffix_name}_pp-rank-{pp_rank}-of-{pp_size}_tp-rank-{tp_rank}-of-{tp_size}_exp-rank-{exp_rank}-of-{exp_size}.safetensors"
-    else:
+    elif version > Version("1.3"):
+        pattern = f"{type.value}_{suffix_name}*.safetensors"
         suffix_name = f"{type.value}_{suffix_name}.safetensors"
 
-    suffix_path.append(suffix_name)
-    if prefix is None:
-        return suffix_path
+    if return_all_matches:
+        if prefix is None:
+            return list(Path(suffix_path[0]).joinpath(*suffix_path[1:]).glob(pattern))
+        else:
+            return list(prefix.joinpath(*suffix_path).glob(pattern))
     else:
-        return prefix.joinpath(*suffix_path)
+        suffix_path.append(suffix_name)
+        if prefix is None:
+            return Path(suffix_path[0]).joinpath(*suffix_path[1:])
+        else:
+            return prefix.joinpath(*suffix_path)
 
 
 def extract_tp_pp_rank_from_shard_path(shard_path: Path):

--- a/src/nanotron/serialize/utils.py
+++ b/src/nanotron/serialize/utils.py
@@ -6,10 +6,10 @@ from typing import List, Optional, Tuple
 import torch
 from packaging.version import Version
 
+from nanotron.constants import CHECKPOINT_VERSION
 from nanotron.parallel import ParallelContext
 from nanotron.parallel.parameters import SlicesPair
 from nanotron.serialize.metadata import TensorMetadata
-from nanotron.constants import CHECKPOINT_VERSION
 
 
 class ObjectType(Enum):
@@ -40,7 +40,6 @@ def get_path(
 ) -> Path | List[Path]:
     suffix = tensor_name.split(".")
     suffix_path, suffix_name = suffix[:-1], suffix[-1]
-
 
     if version == Version("1.3"):
         suffix_name = f"{type.value}_{suffix_name}.safetensors"

--- a/src/nanotron/serialize/weights.py
+++ b/src/nanotron/serialize/weights.py
@@ -289,7 +289,7 @@ def load_weights(
                     prefix=param_root_folder,
                     is_expert_sharded=is_expert_sharded,
                     version=checkpoint_version or CHECKPOINT_VERSION,
-                    return_all_matches=True
+                    return_all_matches=True,
                 )
 
                 if len(shards_path) <= 0:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -113,7 +113,6 @@ def test_save_and_load_with_changed_topolgy(tp1: int, dp1: int, pp1: int, tp2: i
     # Create first model.
     init_distributed(tp=tp1, dp=dp1, pp=pp1)(_create_model_and_serialize_all)(root_path=model1_path)
     assert (model1_path/"model").exists()
-
     assert (model1_path/"inputs.pt").exists()
     assert (model1_path/"outputs.pt").exists()
 


### PR DESCRIPTION
This pull request introduces three main additions:
- [x] 1.3 weights are now backwards compatible, meaning we can load checkpoints that had the `.safetensors` suffix incorrectly placed.
- [x] The logic used to get the filenames of weights shards was moved from `serialize.weights.load_weights` to `serialize.utils.get_path` thanks to the addition of `return_all_matches` keyword.
- [x] Addition of a test that verifies the capability to load weights when changing parallelism topology.