### PR TITLE
Adding Nanoset dataset

### DIFF
--- a/.github/workflows/3d_parallelism_unit_tests.yaml
+++ b/.github/workflows/3d_parallelism_unit_tests.yaml
@@ -45,6 +45,7 @@ jobs:
         pip install -e .
         pip install -e .[dev]
         pip install -e .[test]
+        pip install -e .[nanosets]
 
     - name: Show installed libraries and their versions
       run: pip freeze | tee installed.txt

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -1,0 +1,174 @@
+# Nanosets
+
+## Install
+To use `Nanosets`, it's necessary to install Nanotron with the `nanosets` flavor.
+```
+pip install -e '.[nanosets]'
+```
+
+## Data pre-processing
+
+Nanotron incorporates [`Nanosets`](../src/nanotron/data/nanoset.py), a kind of datasets based on numpy memory-mapped arrays. Permite utilizar tanto un unico dataset como varios, incluso especificando los weights de cada dataset.
+
+
+To use these datasets, first, we need to preprocess the data. The input format can either be a column of a Hugging Face Dataset or a .json file containing a text sample per line. For example:
+
+<pre>
+{"src": "www.nvidia.com", "text": "The quick brown fox", "type": "Eng", "id": "0", "title": "First Part"}
+{"src": "The Internet", "text": "jumps over the lazy dog", "type": "Eng", "id": "42", "title": "Second Part"}
+</pre>
+
+The dataset is then processed into a mmap format for training using the [`tools/preprocess_data.py`](../tools/preprocess_data.py) script. Below we show an example for processing a corpus with the Llama2 tokenizer.
+
+<pre>
+python tools/preprocess_data.py \
+       --input data/my_corpus.json \
+       --output-prefix data/processed-datasets/my-llama2-dataset \
+       --tokenizer-name-or-path meta-llama/Llama-2-7b-hf \
+       --num-workers 128
+</pre>
+
+In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
+
+The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `data_path` field in the config file.
+
+## Working with Nanosets
+
+To work with Nanosets, we just need to configure 1 argument:
+1. `data_path`: This argument specifies the file/files that will compose the `Nanoset`. There are 3 ways to specify it:
+   1. If we specify a single path, we will create a `Nanoset` from a single dataset file.
+    ```yaml
+    data_stages:
+      - name: General purpose training (Single dataset)
+        start_training_step: 1
+        data:
+          dataset:
+            dataset_path: nanosets/SlimPajama-6B_input_ids.npy
+          num_loading_workers: 0
+          seed: 1234
+    ```
+   2. If we specify a list of paths, we will create a `Nanoset` from all the dataset files. In every epoch we will consume each and every sample from each dataset randomly.
+    ```yaml
+    data_stages:
+      - name: Second purpose training (> 1 dataset)
+        start_training_step: 15
+        data:
+          dataset:
+            dataset_path:
+            - nanoset/SlimPajama-6B_input_ids.npy
+            - nanoset/europarl_input_ids.npy
+          num_loading_workers: 0
+          seed: 1234
+    ```
+    3. If we specify a dictionary with paths and weights, we will create a `Nanoset` from the dataset files where each epoch will have a number of samples from each dataset according to the specified weights.
+    ```yaml
+    data_stages:
+      - name: Third purpose training (Blended dataset)
+        start_training_step: 25
+        data:
+          dataset:
+            dataset_path:
+              nanoset/SlimPajama-6B_input_ids.npy: 0.8
+              nanoset/europarl_input_ids.npy: 0.2
+          num_loading_workers: 0
+          seed: 1234
+    ```
+
+Finally, to use the Nanosets, launch the training with [`run_train.py`](../run_train.py).
+```shell
+torchrun --nproc-per-node 8 run_train.py --config configs/nanoset_llama2.yaml
+```
+
+## Under the hood
+### Number of samples
+
+When using Nanosets, we specify the `data_path` to the preprocessed dataset which contains all the tokens. The number of samples will be the `number of tokens / sequence lenght`.
+
+For the train split, the number of samples consumed from the Nanoset will be determined by the `number of train steps * global batch size`, so if this number is higher than the number of samples in the train split, we will see the dataset samples more than once (> 1 epoch). In the case of the valid and test split, we will see all the samples only once.
+
+In the case of the `BlendedNanoset`, we will also indicate the weight of each dataset to construct data batches according to the specified proportion. In this case, the train split will respect this proportion, considering that the number of samples will be computed in the same way as in the `Nanosets`, so it may happen that we consume one dataset for 3 epochs and another larger dataset for only one epoch. For the valid and test splits, the same as in the `Nanosets` will occur; we will consume all the samples only once.
+
+### Nanoset
+A `Nanoset` is paremeterized by the following variables:
+- The underlying `MMapIndexedDataset` instance (`indexed_dataset`)
+- The sequence length `S`
+- The split indices `indexed_indices` (the congituous subset of sample indices used for training, validation, and testing)
+- The total number of samples `N` of the Nanoset that we will consume during training. In the case of the valid and test splits, we will only consume the dataset once
+- The random seed `R`
+
+The `Nanoset` creates a single index (`shuffle_index`) to map the indices of the Nanoset (0, 1, 2, ... `N`) to the indices of the `MMapIndexedDataset` for the specific split (`indexed_indices`).
+
+In the train split, the shuffle index (`shuffle_index`) is a 1-D array mapping from _k_ to _j_ of length `n_concatenations * len(indexed_indices)`, where `n_concatenations` is defined as `(N / len(indexed_indices)) + 1`, so that `len(shuffle_index)` is always greater than `N`. While for the valid and test splits, `len(shuffle_index) == len(indexed_indices)`. Before concatenating the full array, `shuffle_index` is shuffled according to `R`.
+```
+Given:
+
+N = 70
+
+indexed_indices = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+Then, for example:
+
+shuffle_index = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+Shuffle the indices -> shuffle_index = [19, 9, 3, 18, 15, 12, 5, 10, 17, 1, 4, 8, 11, 16, 13, 7, 2, 14, 6, 0]
+
+n_concatenations = (70/(20)) + 1 = 4
+shuffle_index = shuffle_index concatenated 4 times
+
+len(shuffle_index) = 80 > N
+```
+
+To query the `Nanoset` for the k-th sample we do the following:
+1. Use the `shuffle_index` to get the index _j_ into the `sample_index`
+```
+j = shuffle_index[k]
+```
+2. To retrieve `S + 1` tokens from the `indexed_dataset` we have to specify the `offset` (`idx * sequence length` for CausalLM) and the length (the number of tokens to extract)
+```
+offset = j * sequence_length
+sample = indexed_dataset[offset:offset + sequence_length + 1]
+```
+
+Despite having repeated indices in the `shuffle_index`, throughout 1 epoch, we will only observe each sample once. We achieve this by deactivating shuffling in the `DistributedDataSampler`, so that the indices of the `shuffle_index` are consumed in the order they appear by the multiple processes. It is worth noting that the samples are already shuffled in the `shuffle_index`.
+```
+Given:
+
+4 Processes loading data
+
+[19, 9, 3, 18, 15, 12, 5, 10, 17, 1, 4, 8, 11, 16, 13, 7, 2, 14, 6, 0]
+
+(P1) idx_list = [0, 4, 8, 12, 16, ...]    -> shuffle_index[idx_list] = [19, 15, 17, 11, 2, 19, ...]
+(P2) idx_list = [1, 5, 9, 13, 17, ...]    -> shuffle_index[idx_list] = [9, 12, 1, 16, 14, 9, ...]
+(P3) idx_list = [2, 6, 10, 14, 18, ...]   -> shuffle_index[idx_list] = [3, 5, 4, 13, 6, 3, ...]
+(P4) idx_list = [3, 7, 11, 15, 19, ...]   -> shuffle_index[idx_list] = [18, 10, 8, 7, 0, 18, ...]
+```
+### BlendedNanoset
+The `BlendedNanoset` is parameterized by the following variables:
+- The underlying `Nanoset` instances `D`
+- The weights `W` (one per dataset)
+- The number of samples `U`
+
+The `BlendedNanoset` creates two "blending" indices to facilitate lookup: (1) The `dataset_index` and (2) the `dataset_sample_index`.
+
+1. The `dataset_index` is a 1-D array mapping from _i_ to dataset index from `D` of length `U`.
+```
+Given:
+
+D = [d0, d1, d2, d3]
+W = [0.1, 0.5, 0.3, 0.1]
+U = 20
+
+Then, for example:
+
+dataset_index = [1, 2, 0, 1, 3, 1, 2, 1, 2, 1, 0, 1, 2, 1, 3, 1, 2, 1, 2, 1]
+```
+2. The `dataset_sample_index` is a 1-D mapping from _i_ to the sample index for dataset_index[_i_] of length `U`.
+```
+dataset_index =         [1, 2, 0, 1, 3, 1, 2, 1, 2, 1, 0, 1, 2, 1, 3, 1, 2, 1, 2, 1]
+dataset_sample_index =  [0, 0, 0, 1, 0, 2, 1, 3, 2, 4, 1, 5, 3, 6, 1, 7, 4, 8, 5, 9]
+```
+To query the `BlendedNanoset` for the k-th sample we do the following:
+- Use the `dataset_index` to retrieve the corresponding dataset from `D` and the `dataset_sample_index` to retrieve the corresponding sample from that dataset.
+```
+sample = D[dataset_index[k]][dataset_sample_index[k]]
+```

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -73,6 +73,8 @@ To work with `Nanosets`, we just need to configure 1 argument:
           num_loading_workers: 0
           seed: 1234
     ```
+> [!IMPORTANT]
+> Remember to set the `tokenizer.tokenizer_name_or_path` in the config file to the tokenizer used to preprocess the documents and set the `model.model_config.vocab_size` accordingly.
 
 Finally, to use the `Nanosets`, launch the training with [`run_train.py`](../run_train.py).
 ```shell

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -20,11 +20,10 @@ To use these datasets, first, we need to preprocess the data. The input format c
 The preprocessing is done using the [`tools/preprocess_data.py`](../tools/preprocess_data.py) script. Below we show an example for processing a corpus with the Llama2 tokenizer.
 
 <pre>
-python tools/preprocess_data.py \
+torchrun --nproc-per-node 16 tools/preprocess_data.py \
        --input data/my_corpus.json \
        --output-prefix data/processed-datasets/my-llama2-dataset \
-       --tokenizer-name-or-path meta-llama/Llama-2-7b-hf \
-       --num-workers 128
+       --tokenizer-name-or-path meta-llama/Llama-2-7b-hf
 </pre>
 
 In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -21,12 +21,14 @@ The preprocessing is done using the [`tools/preprocess_data.py`](../tools/prepro
 
 <pre>
 torchrun --nproc-per-node 16 tools/preprocess_data.py \
-       --input data/my_corpus.json \
-       --output-prefix data/processed-datasets/my-llama2-dataset \
+       --input HuggingFaceH4/testing_alpaca_small \
+       --split train \
+       --column completion \
+       --output-prefix datasets/testing_alpaca_small \
        --tokenizer-name-or-path meta-llama/Llama-2-7b-hf
 </pre>
 
-In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
+The `--input` dataset can be either a Hugging Face Dataset from the Hub or a `.json` file. The processed dataset will be stored in *`--output-prefix`_input_ids.npy*. In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
 
 The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `dataset_path` field in the config file.
 

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -30,7 +30,7 @@ torchrun --nproc-per-node 16 tools/preprocess_data.py \
 
 The preprocessing script has to be launched with `torchrun` in order to spawn `--nproc-per-node` workers that will preprocess the dataset concurrently. The `--input` dataset can be either a Hugging Face Dataset from the Hub or a `.json` file. The processed dataset will be stored in *`--output-prefix`_input_ids.npy*. In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
 
-The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `dataset_path` field in the config file.
+The output will be one file named, in this case, `datasets/testing_alpaca_small_input_ids.npy`. We will then have to specify this file in the `dataset_path` field in the config file.
 
 ## Working with Nanosets
 
@@ -43,7 +43,7 @@ To work with `Nanosets`, we just need to configure 1 argument:
         start_training_step: 1
         data:
           dataset:
-            dataset_path: nanosets/SlimPajama-6B_input_ids.npy
+            dataset_path: datasets/SlimPajama-6B_input_ids.npy
           num_loading_workers: 0
           seed: 1234
     ```
@@ -55,8 +55,8 @@ To work with `Nanosets`, we just need to configure 1 argument:
         data:
           dataset:
             dataset_path:
-            - nanoset/SlimPajama-6B_input_ids.npy
-            - nanoset/europarl_input_ids.npy
+            - datasets/SlimPajama-6B_input_ids.npy
+            - datasets/testing_alpaca_small_input_ids.npy
           num_loading_workers: 0
           seed: 1234
     ```
@@ -68,8 +68,8 @@ To work with `Nanosets`, we just need to configure 1 argument:
         data:
           dataset:
             dataset_path:
-              nanoset/SlimPajama-6B_input_ids.npy: 0.8
-              nanoset/europarl_input_ids.npy: 0.2
+              datasets/SlimPajama-6B_input_ids.npy: 0.8
+              datasets/testing_alpaca_small_input_ids.npy: 0.2
           num_loading_workers: 0
           seed: 1234
     ```

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -28,7 +28,7 @@ torchrun --nproc-per-node 16 tools/preprocess_data.py \
        --tokenizer-name-or-path meta-llama/Llama-2-7b-hf
 </pre>
 
-The `--input` dataset can be either a Hugging Face Dataset from the Hub or a `.json` file. The processed dataset will be stored in *`--output-prefix`_input_ids.npy*. In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
+The preprocessing script has to be launched with `torchrun` in order to spawn `--nproc-per-node` workers that will preprocess the dataset concurrently. The `--input` dataset can be either a Hugging Face Dataset from the Hub or a `.json` file. The processed dataset will be stored in *`--output-prefix`_input_ids.npy*. In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
 
 The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `dataset_path` field in the config file.
 

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -1,16 +1,15 @@
 # Nanosets
-
+Nanotron incorporates [`Nanosets`](../src/nanotron/data/nanoset.py), a kind of datasets based on [numpy memory-mapped arrays](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html). `Nanosets` are capable of serving batches from files containing pre-tokenized datasets. They allow reading tokens from one or multiple datasets and even specifying the weight of each dataset when building batches.
 ## Install
 To use `Nanosets`, it's necessary to install Nanotron with the `nanosets` flavor.
 ```
 pip install -e '.[nanosets]'
 ```
-
+This will install the following dependencies:
+- `transformers`: To tokenize the datasets
+- `datasets`: To preprocess the datasets
+- `numba`: To compile helper functions in order to speed up the creation of `Nanosets`
 ## Data pre-processing
-
-Nanotron incorporates [`Nanosets`](../src/nanotron/data/nanoset.py), a kind of datasets based on numpy memory-mapped arrays. Permite utilizar tanto un unico dataset como varios, incluso especificando los weights de cada dataset.
-
-
 To use these datasets, first, we need to preprocess the data. The input format can either be a column of a Hugging Face Dataset or a .json file containing a text sample per line. For example:
 
 <pre>
@@ -18,7 +17,7 @@ To use these datasets, first, we need to preprocess the data. The input format c
 {"src": "The Internet", "text": "jumps over the lazy dog", "type": "Eng", "id": "42", "title": "Second Part"}
 </pre>
 
-The dataset is then processed into a mmap format for training using the [`tools/preprocess_data.py`](../tools/preprocess_data.py) script. Below we show an example for processing a corpus with the Llama2 tokenizer.
+The preprocessing is done using the [`tools/preprocess_data.py`](../tools/preprocess_data.py) script. Below we show an example for processing a corpus with the Llama2 tokenizer.
 
 <pre>
 python tools/preprocess_data.py \
@@ -30,12 +29,12 @@ python tools/preprocess_data.py \
 
 In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
 
-The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `data_path` field in the config file.
+The output will be one file named, in this case, `my-llama2-dataset_input_ids.npy`. We will then have to specify this file in the `dataset_path` field in the config file.
 
 ## Working with Nanosets
 
-To work with Nanosets, we just need to configure 1 argument:
-1. `data_path`: This argument specifies the file/files that will compose the `Nanoset`. There are 3 ways to specify it:
+To work with `Nanosets`, we just need to configure 1 argument:
+1. `dataset_path`: This argument specifies the file or files that will compose the `Nanoset`. There are 3 ways to specify it:
    1. If we specify a single path, we will create a `Nanoset` from a single dataset file.
     ```yaml
     data_stages:
@@ -74,100 +73,55 @@ To work with Nanosets, we just need to configure 1 argument:
           seed: 1234
     ```
 
-Finally, to use the Nanosets, launch the training with [`run_train.py`](../run_train.py).
+Finally, to use the `Nanosets`, launch the training with [`run_train.py`](../run_train.py).
 ```shell
 torchrun --nproc-per-node 8 run_train.py --config configs/nanoset_llama2.yaml
 ```
 
 ## Under the hood
-### Number of samples
+`Nanosets` are responsible of building samples of `sequence length + 1` tokens from the preprocessed dataset files. The `dataset lengths` of each dataset will be determined by the `number of total tokens / sequence length`, discarding the last sample since its length < `sequence length`.
 
-When using Nanosets, we specify the `data_path` to the preprocessed dataset which contains all the tokens. The number of samples will be the `number of tokens / sequence lenght`.
-
-For the train split, the number of samples consumed from the Nanoset will be determined by the `number of train steps * global batch size`, so if this number is higher than the number of samples in the train split, we will see the dataset samples more than once (> 1 epoch). In the case of the valid and test split, we will see all the samples only once.
-
-In the case of the `BlendedNanoset`, we will also indicate the weight of each dataset to construct data batches according to the specified proportion. In this case, the train split will respect this proportion, considering that the number of samples will be computed in the same way as in the `Nanosets`, so it may happen that we consume one dataset for 3 epochs and another larger dataset for only one epoch. For the valid and test splits, the same as in the `Nanosets` will occur; we will consume all the samples only once.
-
-### Nanoset
-A `Nanoset` is paremeterized by the following variables:
-- The underlying `MMapIndexedDataset` instance (`indexed_dataset`)
-- The sequence length `S`
-- The split indices `indexed_indices` (the congituous subset of sample indices used for training, validation, and testing)
-- The total number of samples `N` of the Nanoset that we will consume during training. In the case of the valid and test splits, we will only consume the dataset once
-- The random seed `R`
-
-The `Nanoset` creates a single index (`shuffle_index`) to map the indices of the Nanoset (0, 1, 2, ... `N`) to the indices of the `MMapIndexedDataset` for the specific split (`indexed_indices`).
-
-In the train split, the shuffle index (`shuffle_index`) is a 1-D array mapping from _k_ to _j_ of length `n_concatenations * len(indexed_indices)`, where `n_concatenations` is defined as `(N / len(indexed_indices)) + 1`, so that `len(shuffle_index)` is always greater than `N`. While for the valid and test splits, `len(shuffle_index) == len(indexed_indices)`. Before concatenating the full array, `shuffle_index` is shuffled according to `R`.
+Based on the `dataset lengths`, the `dataset weights` and the `number of samples per epoch` (defined as the `sum(dataset lengths)`), we build the two indexes we need in order to extract samples from the `Nanoset`  ([build_nanoset_index_helper](../src/nanotron/data/nanoset.py)):
+- `dataset index`: Contains the index of the dataset from the list of `dataset paths` from which to extract the sample, respecting the established dataset weight.
 ```
 Given:
 
-N = 70
-
-indexed_indices = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-
-Then, for example:
-
-shuffle_index = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-
-Shuffle the indices -> shuffle_index = [19, 9, 3, 18, 15, 12, 5, 10, 17, 1, 4, 8, 11, 16, 13, 7, 2, 14, 6, 0]
-
-n_concatenations = (70/(20)) + 1 = 4
-shuffle_index = shuffle_index concatenated 4 times
-
-len(shuffle_index) = 80 > N
-```
-
-To query the `Nanoset` for the k-th sample we do the following:
-1. Use the `shuffle_index` to get the index _j_ into the `sample_index`
-```
-j = shuffle_index[k]
-```
-2. To retrieve `S + 1` tokens from the `indexed_dataset` we have to specify the `offset` (`idx * sequence length` for CausalLM) and the length (the number of tokens to extract)
-```
-offset = j * sequence_length
-sample = indexed_dataset[offset:offset + sequence_length + 1]
-```
-
-Despite having repeated indices in the `shuffle_index`, throughout 1 epoch, we will only observe each sample once. We achieve this by deactivating shuffling in the `DistributedDataSampler`, so that the indices of the `shuffle_index` are consumed in the order they appear by the multiple processes. It is worth noting that the samples are already shuffled in the `shuffle_index`.
-```
-Given:
-
-4 Processes loading data
-
-[19, 9, 3, 18, 15, 12, 5, 10, 17, 1, 4, 8, 11, 16, 13, 7, 2, 14, 6, 0]
-
-(P1) idx_list = [0, 4, 8, 12, 16, ...]    -> shuffle_index[idx_list] = [19, 15, 17, 11, 2, 19, ...]
-(P2) idx_list = [1, 5, 9, 13, 17, ...]    -> shuffle_index[idx_list] = [9, 12, 1, 16, 14, 9, ...]
-(P3) idx_list = [2, 6, 10, 14, 18, ...]   -> shuffle_index[idx_list] = [3, 5, 4, 13, 6, 3, ...]
-(P4) idx_list = [3, 7, 11, 15, 19, ...]   -> shuffle_index[idx_list] = [18, 10, 8, 7, 0, 18, ...]
-```
-### BlendedNanoset
-The `BlendedNanoset` is parameterized by the following variables:
-- The underlying `Nanoset` instances `D`
-- The weights `W` (one per dataset)
-- The number of samples `U`
-
-The `BlendedNanoset` creates two "blending" indices to facilitate lookup: (1) The `dataset_index` and (2) the `dataset_sample_index`.
-
-1. The `dataset_index` is a 1-D array mapping from _i_ to dataset index from `D` of length `U`.
-```
-Given:
-
-D = [d0, d1, d2, d3]
-W = [0.1, 0.5, 0.3, 0.1]
-U = 20
+D = [d0, d1, d2, d3]        # datasets
+DL = [8, 2, 5, 5]           # dataset lengths
+W = [0.1, 0.5, 0.3, 0.1]    # dataset weights
+SPE = 20                    # number of samples per epoch
 
 Then, for example:
 
 dataset_index = [1, 2, 0, 1, 3, 1, 2, 1, 2, 1, 0, 1, 2, 1, 3, 1, 2, 1, 2, 1]
 ```
-2. The `dataset_sample_index` is a 1-D mapping from _i_ to the sample index for dataset_index[_i_] of length `U`.
+- `dataset sample index`: Contains the sample index to extract from the `dataset index[index]` dataset, always < `len(dataset)`.
 ```
 dataset_index =         [1, 2, 0, 1, 3, 1, 2, 1, 2, 1, 0, 1, 2, 1, 3, 1, 2, 1, 2, 1]
-dataset_sample_index =  [0, 0, 0, 1, 0, 2, 1, 3, 2, 4, 1, 5, 3, 6, 1, 7, 4, 8, 5, 9]
+dataset_sample_index =  [0, 0, 0, 1, 0, 0, 1, 1, 2, 0, 1, 1, 3, 0, 1, 1, 4, 0, 0, 1]
 ```
-To query the `BlendedNanoset` for the k-th sample we do the following:
+Then, we **shuffle with the same permutation both indexes** and concatenate them `number of epochs` times, which is defined by `train split num samples` / `number of samples per epoch`.
+```
+Given:
+
+N = 70                      # train split num samples
+
+dataset_index =         [1, 2, 0, 1, 3, 1, 2, 1, 2, 1, 0, 1, 2, 1, 3, 1, 2, 1, 2, 1]
+dataset_sample_index =  [0, 0, 0, 1, 0, 0, 1, 1, 2, 0, 1, 1, 3, 0, 1, 1, 4, 0, 0, 1]
+
+Shuffle dataset_index and dataset_sample_index:
+
+dataset_index =         [1, 1, 0, 2, 3, 1, 3, 1, 2, 2, 1, 1, 0, 1, 1, 2, 1, 2, 2, 1]
+dataset_sample_index =  [1, 0, 0, 4, 1, 0, 0, 0, 2, 0, 0, 1, 1, 0, 1, 0, 1, 3, 1, 1]
+
+n_concatenations = (70/(20)) + 1 = 4
+dataset_index = dataset_index concatenated 4 times
+dataset_sample_index = dataset_sample_index concatenated 4 times
+
+dataset_index = dataset_index[: N]
+dataset_sample_index = dataset_sample_index[: N]
+```
+To query the `Nanoset` for the k-th sample we do the following:
 - Use the `dataset_index` to retrieve the corresponding dataset from `D` and the `dataset_sample_index` to retrieve the corresponding sample from that dataset.
 ```
 sample = D[dataset_index[k]][dataset_sample_index[k]]

--- a/docs/nanoset.md
+++ b/docs/nanoset.md
@@ -25,7 +25,7 @@ torchrun --nproc-per-node 16 tools/preprocess_data.py \
        --split train \
        --column completion \
        --output-prefix datasets/testing_alpaca_small \
-       --tokenizer-name-or-path meta-llama/Llama-2-7b-hf
+       --tokenizer-name-or-path openai-community/gpt2
 </pre>
 
 The preprocessing script has to be launched with `torchrun` in order to spawn `--nproc-per-node` workers that will preprocess the dataset concurrently. The `--input` dataset can be either a Hugging Face Dataset from the Hub or a `.json` file. The processed dataset will be stored in *`--output-prefix`_input_ids.npy*. In `--tokenizer-name-or-path`, we will have to specify a tokenizer in the same way as we do when using `AutoTokenizers.from_pretrained(...)`.
@@ -78,11 +78,11 @@ To work with `Nanosets`, we just need to configure 1 argument:
 
 Finally, to use the `Nanosets`, launch the training with [`run_train.py`](../run_train.py).
 ```shell
-torchrun --nproc-per-node 8 run_train.py --config configs/nanoset_llama2.yaml
+torchrun --nproc-per-node 8 run_train.py --config configs/config_nanoset.yaml
 ```
 
 ## Under the hood
-`Nanosets` are responsible of building samples of `sequence length + 1` tokens from the preprocessed dataset files. The `dataset lengths` of each dataset will be determined by the `number of total tokens / sequence length`, discarding the last sample since its length < `sequence length`.
+`Nanosets` are responsible of building samples of `sequence length + 1` tokens from the preprocessed dataset files. The `dataset lengths` of each dataset will be determined by the `(dataset_number_of_tokens - 1) / sequence length`, discarding the last sample if its length < `sequence length`.
 
 Based on the `dataset lengths`, the `dataset weights` and the `number of samples per epoch` (defined as the `sum(dataset lengths)`), we build the two indexes we need in order to extract samples from the `Nanoset`  ([build_nanoset_index_helper](../src/nanotron/data/nanoset.py)):
 - `dataset index`: Contains the index of the dataset from the list of `dataset paths` from which to extract the sample, respecting the established dataset weight.

--- a/examples/config_nanoset.yaml
+++ b/examples/config_nanoset.yaml
@@ -1,0 +1,110 @@
+checkpoints:
+  checkpoint_interval: 1000
+  checkpoints_path: /mloscratch/homes/solergib/nanotron/checkpoints
+  checkpoints_path_is_shared_file_system: false
+  resume_checkpoint_path: null
+  save_initial_state: false
+data_stages:
+- data:
+    dataset:
+      dataset_path: datasets/testing_alpaca_small_input_ids.npy
+    num_loading_workers: 1
+    seed: 42
+  name: General purpose training (Single dataset)
+  start_training_step: 1
+- data:
+    dataset:
+      dataset_path:
+      - datasets/yelp_review_full_input_ids.npy
+      - datasets/testing_alpaca_small_input_ids.npy
+    num_loading_workers: 1
+    seed: 42
+  name: Second purpose training (> 1 dataset)
+  start_training_step: 15
+- data:
+    dataset:
+      dataset_path:
+        datasets/testing_alpaca_small_input_ids.npy: 0.8
+        datasets/yelp_review_full_input_ids.npy: 0.2
+    num_loading_workers: 1
+    seed: 42
+  name: Third purpose training (Blended dataset)
+  start_training_step: 25
+general:
+  benchmark_csv_path: null
+  consumed_train_samples: null
+  ignore_sanity_checks: true
+  project: Nanoset
+  run: llama
+  seed: 42
+  step: null
+lighteval: null
+logging:
+  iteration_step_info_interval: 1
+  log_level: info
+  log_level_replica: info
+model:
+  ddp_bucket_cap_mb: 25
+  dtype: bfloat16
+  init_method:
+    std: 0.025
+  make_vocab_size_divisible_by: 1
+  model_config:
+    bos_token_id: 1
+    eos_token_id: 2
+    hidden_act: silu
+    hidden_size: 16
+    initializer_range: 0.02
+    intermediate_size: 64
+    is_llama_config: true
+    max_position_embeddings: 256
+    num_attention_heads: 4
+    num_hidden_layers: 2
+    num_key_value_heads: 4
+    pad_token_id: null
+    pretraining_tp: 1
+    rms_norm_eps: 1.0e-05
+    rope_scaling: null
+    tie_word_embeddings: true
+    use_cache: true
+    vocab_size: 32000
+optimizer:
+  accumulate_grad_in_fp32: true
+  clip_grad: 1.0
+  learning_rate_scheduler:
+    learning_rate: 0.0003
+    lr_decay_starting_step: null
+    lr_decay_steps: 98
+    lr_decay_style: cosine
+    lr_warmup_steps: 2
+    lr_warmup_style: linear
+    min_decay_lr: 1.0e-05
+  optimizer_factory:
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    name: adamW
+    torch_adam_is_fused: true
+  weight_decay: 0.01
+  zero_stage: 0
+parallelism:
+  dp: 2
+  expert_parallel_size: 1
+  pp: 1
+  pp_engine: 1f1b
+  tp: 2
+  tp_linear_async_communication: true
+  tp_mode: REDUCE_SCATTER
+profiler: null
+tokenizer:
+  tokenizer_max_length: null
+  tokenizer_name_or_path: gpt2
+  tokenizer_revision: null
+tokens:
+  batch_accumulation_per_replica: 1
+  limit_test_batches: 0
+  limit_val_batches: 0
+  micro_batch_size: 2
+  sequence_length: 128
+  train_steps: 200
+  val_check_interval: -1

--- a/examples/config_nanoset.yaml
+++ b/examples/config_nanoset.yaml
@@ -1,6 +1,6 @@
 checkpoints:
   checkpoint_interval: 1000
-  checkpoints_path: /mloscratch/homes/solergib/nanotron/checkpoints
+  checkpoints_path: checkpoints/
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: null
   save_initial_state: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "packaging",
     "safetensors",
     "dacite",
-    "tqdm"
+    "tqdm",
 ]
 
 [tool.setuptools.packages.find]
@@ -45,6 +45,12 @@ test = [
 
 fast-modeling = [
     "flash-attn>=2.5.0",
+]
+
+nanosets = [
+     "transformers",
+     "datasets",
+     "numba",
 ]
 
 [build-system]

--- a/run_train.py
+++ b/run_train.py
@@ -11,11 +11,9 @@ import argparse
 from typing import Dict, cast
 
 from nanotron import logging
-from nanotron.config import (
-    DataArgs,
-    DatasetStageArgs,
-    PretrainDatasetsArgs,
-)
+from nanotron.config import DataArgs, DatasetStageArgs, NanosetDatasetsArgs, PretrainDatasetsArgs
+from nanotron.data.dataloader_builder import build_nanoset_dataloader
+from nanotron.data.nanoset import Nanoset
 from nanotron.dataloader import (
     clm_process,
     dummy_infinite_data_generator,
@@ -135,6 +133,33 @@ def get_dataloader_from_data_stage(
                 f"Dataset is too small for steps ({total_tokens_dataset} < {num_tokens_needed_for_training}), "
                 f"Try train_steps<={len(dataloader.dataset) // trainer.global_batch_size + trainer.start_iteration_step}"
             )
+
+    # Case 3: Nanosets
+    elif isinstance(data.dataset, NanosetDatasetsArgs):
+        # Create Nanoset
+        with main_rank_first(trainer.parallel_context.world_pg):
+            train_dataset = Nanoset(
+                dataset_paths=data.dataset.dataset_path,
+                dataset_weights=data.dataset.dataset_weights,
+                sequence_length=trainer.sequence_length,
+                train_split_num_samples=trainer.config.tokens.train_steps * trainer.global_batch_size,
+                random_seed=data.seed,
+            )
+
+        # Prepare dataloader
+        train_dataloader = build_nanoset_dataloader(
+            train_dataset,
+            trainer.sequence_length,
+            parallel_context=trainer.parallel_context,
+            input_pp_rank=input_pp_rank,
+            output_pp_rank=output_pp_rank,
+            micro_batch_size=trainer.micro_batch_size,
+            consumed_train_samples=consumed_train_samples,
+            dataloader_num_workers=data.num_loading_workers,
+            dataloader_drop_last=True,
+        )
+
+        return train_dataloader
     else:
         raise ValueError(f"Unhandled case of `self.config.data.dataset`. Got: {data.dataset}")
 

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -92,10 +92,27 @@ class PretrainDatasetsArgs:
 
 
 @dataclass
+class NanosetDatasetsArgs:
+    dataset_path: Union[str, dict, List[str]]
+    # dataset_weights: Optional[List] = field(init=False, default=None)
+
+    def __post_init__(self):
+        if isinstance(self.dataset_path, str):  # Case 1: 1 Dataset file
+            self.dataset_path = [self.dataset_path]
+            self.dataset_weights = [1]
+        elif isinstance(self.dataset_path, List):  # Case 2: > 1 Dataset file
+            self.dataset_weights = None  # Set to None so we consume all the samples randomly
+        elif isinstance(self.dataset_path, dict):  # Case 3: dict with > 1 dataset_path and weights
+            tmp_dataset_path = self.dataset_path.copy()
+            self.dataset_path = list(tmp_dataset_path.keys())
+            self.dataset_weights = list(tmp_dataset_path.values())
+
+
+@dataclass
 class DataArgs:
     """Arguments related to the data and data files processing"""
 
-    dataset: Optional[PretrainDatasetsArgs]
+    dataset: Union[PretrainDatasetsArgs, NanosetDatasetsArgs]
     seed: Optional[int]
     num_loading_workers: Optional[int] = 1
 

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -94,7 +94,6 @@ class PretrainDatasetsArgs:
 @dataclass
 class NanosetDatasetsArgs:
     dataset_path: Union[str, dict, List[str]]
-    # dataset_weights: Optional[List] = field(init=False, default=None)
 
     def __post_init__(self):
         if isinstance(self.dataset_path, str):  # Case 1: 1 Dataset file

--- a/src/nanotron/data/dataloader_builder.py
+++ b/src/nanotron/data/dataloader_builder.py
@@ -1,0 +1,64 @@
+import nanotron.distributed as dist
+from nanotron import logging
+from nanotron.dataloader import (
+    DataCollatorForCLM,
+    EmptyInfiniteDataset,
+    get_dataloader_worker_init,
+    get_sampler,
+)
+from nanotron.parallel import ParallelContext
+from torch.utils.data import DataLoader
+
+logger = logging.get_logger(__name__)
+
+
+def build_nanoset_dataloader(
+    dataset,
+    sequence_length: int,
+    parallel_context: ParallelContext,
+    input_pp_rank: int,
+    output_pp_rank: int,
+    micro_batch_size: int,
+    dataloader_num_workers: int,
+    consumed_train_samples: int = 0,
+    dataloader_drop_last: bool = True,
+    dataloader_pin_memory: bool = True,
+) -> DataLoader:
+
+    # Case of ranks not requiring data. We give them a dummy dataset, then the collator will do his job
+    if dist.get_rank(parallel_context.pp_pg) not in [input_pp_rank, output_pp_rank]:
+        dataset_length = len(dataset)
+        dataset = EmptyInfiniteDataset(length=dataset_length)
+        # No need to spawn a lot of workers, we can just use main
+        dataloader_num_workers = 0
+
+    data_collator = DataCollatorForCLM(
+        sequence_length=sequence_length,
+        input_pp_rank=input_pp_rank,
+        output_pp_rank=output_pp_rank,
+        parallel_context=parallel_context,
+    )
+
+    # Compute size and rank of dataloader workers
+    dp_ranks_size = parallel_context.dp_pg.size()
+    dp_rank = parallel_context.dp_pg.rank()
+
+    sampler = get_sampler(
+        train_dataset=dataset,
+        dl_ranks_size=dp_ranks_size,
+        dl_rank=dp_rank,
+        drop_last=dataloader_drop_last,
+        consumed_train_samples=consumed_train_samples,
+        shuffle=False,
+    )
+
+    return DataLoader(
+        dataset,
+        batch_size=micro_batch_size,
+        sampler=sampler,
+        collate_fn=data_collator,
+        drop_last=dataloader_drop_last,
+        num_workers=dataloader_num_workers,
+        pin_memory=dataloader_pin_memory,
+        worker_init_fn=get_dataloader_worker_init(dp_rank=dp_rank),
+    )

--- a/src/nanotron/data/nanoset.py
+++ b/src/nanotron/data/nanoset.py
@@ -158,7 +158,7 @@ def build_nanoset_index_helper(
     """
     # Create empty arrays for dataset indices and dataset sample indices
     dataset_index = np.empty((n_samples,), dtype="uint")
-    dataset_sample_index = np.empty((n_samples,), dtype="long")
+    dataset_sample_index = np.empty((n_samples,), dtype="long")  # Supports dataset with up to 2**64 samples
 
     # Initialize buffer for number of samples used for each dataset
     current_samples = np.zeros((len(weights),), dtype="long")

--- a/src/nanotron/data/nanoset.py
+++ b/src/nanotron/data/nanoset.py
@@ -1,0 +1,183 @@
+from typing import Dict, List, Tuple, Union
+
+import numpy as np
+import torch
+from nanotron import logging
+from nanotron.data.utils import count_dataset_indexes, normalize
+from nanotron.logging import log_rank
+from numba import jit
+
+logger = logging.get_logger(__name__)
+
+
+class Nanoset(torch.utils.data.Dataset):
+    """
+    The Nanoset dataset
+
+    Args:
+        dataset_paths (List[str]): List of paths to tokenized datasets
+        dataset_weights (List[float]): List with the weights for weighted datasets. If None, consume all samples from all datasets without weighting. Weights are normalized in __init__
+        sequence_length (int): Sequence length of the built samples
+        train_split_num_samples (int): Number of samples the dataset needs. It's the training steps * global batch size
+    """
+
+    def __init__(
+        self,
+        dataset_paths: List[str],
+        dataset_weights: Union[List[float], None],
+        sequence_length: int,
+        train_split_num_samples: int,
+        random_seed: int = 1234,
+    ) -> None:
+
+        # Init
+        self.dataset_paths = dataset_paths
+        self.dataset_weights = dataset_weights
+        self.sequence_length = sequence_length
+        self.train_split_num_samples = train_split_num_samples
+        self.random_seed = random_seed
+
+        # Build Nanoset Index
+        ## To build the index we need the length of each dataset
+        self.dataset_lengths = []
+        for dataset_path in self.dataset_paths:
+            self.dataset_buffer_mmap = np.memmap(dataset_path, mode="r", order="C", dtype=np.uint16)
+            self.dataset_buffer = memoryview(self.dataset_buffer_mmap)
+            dataset_tokens = int(len(self.dataset_buffer))
+            number_of_samples = int(
+                dataset_tokens / sequence_length
+            )  # Discard last sample of length < sequence_length
+            self.dataset_lengths.append(number_of_samples)
+        ## Set dataset weights
+        if (
+            self.dataset_weights is None
+        ):  # Case of training with > 1 datasets without weighting them: Consume both datasets entirely on each epoch
+            self.dataset_weights = normalize(self.dataset_lengths)
+        else:
+            self.dataset_weights = normalize(dataset_weights)
+        ## Build dataset index and dataset sample index
+        self.dataset_index, self.dataset_sample_index = self.build_nanoset_index()
+
+        self.print_nanoset_info()
+
+    def __len__(self) -> int:
+        """
+        Returns:
+            int: The number of samples of the Nanoset
+        """
+
+        return len(self.dataset_index)
+
+    def __getitem__(self, idx: int) -> Dict[str, np.ndarray]:
+        """
+        Returns sequence_length + 1 tokens from the memmap dataset
+
+        Args:
+            idx (int): The index into the dataset
+
+        Returns:
+            Dict[str, numpy.ndarray]: The input ids wrapped in a dictionary
+        """
+
+        dataset = self.dataset_index[idx]
+        dataset_sample = self.dataset_sample_index[idx]
+
+        # Rebuild the memmap in every access to free memory
+        # https://stackoverflow.com/a/61472122
+        self.dataset_buffer_mmap = np.memmap(self.dataset_paths[dataset], mode="r", order="C", dtype=np.uint16)
+        self.dataset_buffer = memoryview(self.dataset_buffer_mmap)
+
+        # dtype=uint16, 2 bytes per token
+        offset = dataset_sample * self.sequence_length * 2
+        input_ids_tokens = np.frombuffer(
+            self.dataset_buffer, dtype=np.uint16, count=(self.sequence_length + 1), offset=offset
+        )
+
+        # Return tokens as np.int32 as Torch can't handle uint16
+        return {"input_ids": input_ids_tokens.astype(np.int32)}
+
+    def build_nanoset_index(self) -> np.ndarray:
+        """
+        Build dataset index and dataset sample index
+        """
+        # Compute samples per epoch and number of epochs
+        samples_per_epoch = sum(self.dataset_lengths)
+        num_epochs = int(self.train_split_num_samples / samples_per_epoch) + 1
+        # Build the dataset indexes for 1 epoch
+        dataset_index, dataset_sample_index = build_nanoset_index_helper(
+            n_samples=samples_per_epoch, weights=self.dataset_weights, dataset_sizes=self.dataset_lengths
+        )
+        # Shuffle the indexes the same way
+        numpy_random_state = np.random.RandomState(self.random_seed)
+        numpy_random_state.shuffle(dataset_index)
+        numpy_random_state = np.random.RandomState(self.random_seed)
+        numpy_random_state.shuffle(dataset_sample_index)
+        # Concatenate num_epochs the shuffled indexes
+        dataset_index = np.concatenate([dataset_index for _ in range(num_epochs)])
+        dataset_sample_index = np.concatenate([dataset_sample_index for _ in range(num_epochs)])
+        # Just keep the necessary samples
+        dataset_index = dataset_index[: self.train_split_num_samples]
+        dataset_sample_index = dataset_sample_index[: self.train_split_num_samples]
+
+        return dataset_index, dataset_sample_index
+
+    def __del__(self) -> None:
+        """
+        Clean up Nanoset
+        """
+
+        if hasattr(self, "dataset_buffer_mmap"):
+            self.dataset_buffer_mmap._mmap.close()
+        del self.dataset_buffer_mmap
+
+    def print_nanoset_info(self):
+
+        log_rank(f"> Total number of samples: {len(self)}", logger=logger, level=logging.INFO, rank=0)
+        log_rank(
+            f"> Total number of tokens: {len(self) * self.sequence_length}", logger=logger, level=logging.INFO, rank=0
+        )
+
+        # Print samples from each dataset + weight
+        dataset_sample_count = count_dataset_indexes(self.dataset_index, len(self.dataset_paths))
+        for index, sample_count in enumerate(dataset_sample_count):
+            log_rank(
+                f">   Total number of samples from the {self.dataset_paths[index].rsplit('/', 1)[-1]} dataset: {sample_count} ({round(normalize(dataset_sample_count).tolist()[index], 2)})",
+                logger=logger,
+                level=logging.INFO,
+                rank=0,
+            )
+
+
+@jit(nopython=True, cache=True)
+def build_nanoset_index_helper(
+    n_samples: int, weights: np.ndarray, dataset_sizes: List[int]
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Given multiple datasets and a weighting array, build samples indexes
+    such that it follows those weights
+    """
+    # Create empty arrays for dataset indices and dataset sample indices
+    dataset_index = np.empty((n_samples,), dtype="uint")
+    dataset_sample_index = np.empty((n_samples,), dtype="long")
+
+    # Initialize buffer for number of samples used for each dataset
+    current_samples = np.zeros((len(weights),), dtype="long")
+
+    # Iterate over all samples
+    for sample_idx in range(n_samples):
+
+        # Convert sample index to float for comparison against weights
+        sample_idx_float = max(sample_idx, 1.0)
+
+        # Find the dataset with the highest error
+        errors = weights * sample_idx_float - current_samples
+        max_error_index = np.argmax(errors)
+
+        # Assign the dataset index and update the sample index
+        dataset_index[sample_idx] = max_error_index
+        dataset_sample_index[sample_idx] = current_samples[max_error_index] % dataset_sizes[max_error_index]
+
+        # Update the total samples for the selected dataset
+        current_samples[max_error_index] += 1
+
+    return dataset_index, dataset_sample_index

--- a/src/nanotron/data/nanoset.py
+++ b/src/nanotron/data/nanoset.py
@@ -46,10 +46,10 @@ class Nanoset(torch.utils.data.Dataset):
         for dataset_path in self.dataset_paths:
             self.dataset_buffer_mmap = np.memmap(dataset_path, mode="r", order="C", dtype=self.token_dtype)
             self.dataset_buffer = memoryview(self.dataset_buffer_mmap)
-            dataset_tokens = int(len(self.dataset_buffer))
+            dataset_number_of_tokens = int(len(self.dataset_buffer))
             number_of_samples = int(
-                dataset_tokens / sequence_length
-            )  # Discard last sample of length < sequence_length
+                (dataset_number_of_tokens - 1) / sequence_length
+            )  # Discard last sample if length < sequence_length
             self.dataset_lengths.append(number_of_samples)
         ## Set dataset weights
         if (

--- a/src/nanotron/data/utils.py
+++ b/src/nanotron/data/utils.py
@@ -1,0 +1,28 @@
+from typing import List
+
+import numpy as np
+
+
+def normalize(weights: List[float]) -> List[np.array]:
+    """
+    Normalize elements of a list
+
+    Args:
+        weights (List[float]): The weights
+
+    Returns:
+        List[numpy.array]: The normalized weights
+    """
+    w = np.array(weights, dtype=np.float64)
+    w_sum = np.sum(w)
+    w = w / w_sum
+    return w
+
+
+def count_dataset_indexes(dataset_idx: np.ndarray, n_datasets: int):
+    counts = []
+
+    for dataset in range(n_datasets):
+        counts.append(np.count_nonzero(dataset_idx == dataset))
+
+    return counts

--- a/src/nanotron/dataloader.py
+++ b/src/nanotron/dataloader.py
@@ -19,6 +19,9 @@ from nanotron.sanity_checks import (
 )
 
 try:
+    from transformers import PreTrainedTokenizerBase
+    from transformers.trainer_pt_utils import DistributedSamplerWithLoop
+
     import datasets
     from datasets import (
         Dataset,
@@ -29,8 +32,6 @@ try:
         concatenate_datasets,
         load_dataset,
     )
-    from transformers import PreTrainedTokenizerBase
-    from transformers.trainer_pt_utils import DistributedSamplerWithLoop
 except ImportError:
     warnings.warn("Datasets and/or Transformers not installed, you'll be unable to use the dataloader.")
 
@@ -85,7 +86,6 @@ def sanity_check_dataloader(
 # Adapted from h4/src/h4/data/loading.py
 def get_datasets(
     hf_dataset_or_datasets: Union[dict, str],
-    hf_dataset_config_name: Optional[str] = None,
     splits: Optional[Union[List[str], str]] = ["train", "test"],
 ) -> "DatasetDict":
     """
@@ -117,9 +117,6 @@ def get_datasets(
         for split in splits:
             raw_datasets[split] = load_dataset(
                 hf_dataset_or_datasets,
-                # NOTE: weird shit, I can't pass config_name=config_name
-                # have to pass it as positional arguments!!
-                hf_dataset_config_name,
                 split=split,
             )
     else:
@@ -351,10 +348,10 @@ class DataCollatorForCLM:
         ]:
             assert all(len(example) == 0 for example in examples)
             return {
-                "input_ids": TensorPointer(self.input_pp_rank),
-                "input_mask": TensorPointer(self.input_pp_rank),
-                "label_ids": TensorPointer(self.output_pp_rank),
-                "label_mask": TensorPointer(self.output_pp_rank),
+                "input_ids": TensorPointer(group_rank=self.input_pp_rank),
+                "input_mask": TensorPointer(group_rank=self.input_pp_rank),
+                "label_ids": TensorPointer(group_rank=self.output_pp_rank),
+                "label_mask": TensorPointer(group_rank=self.output_pp_rank),
             }
 
         # Make sure we load only what's necessary, ie we only load a `input_ids` column.
@@ -402,15 +399,16 @@ class DataCollatorForCLM:
 
 
 # Adapted from https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/src/transformers/trainer.py#L763-L835
-def _get_train_sampler(
+def get_sampler(
     dl_ranks_size: int,
     dl_rank: int,
-    train_dataset: "Dataset",
-    seed: int,
-    use_loop_to_round_batch_size: bool,
+    train_dataset: Union["Dataset", torch.utils.data.Dataset],
     consumed_train_samples: int,
+    seed: int = 42,
+    use_loop_to_round_batch_size: bool = False,
     micro_batch_size: Optional[int] = None,
     drop_last: Optional[bool] = True,
+    shuffle: bool = True,
 ) -> Optional[torch.utils.data.Sampler]:
     """returns sampler that restricts data loading to a subset of the dataset proper to the DP rank"""
 
@@ -430,7 +428,7 @@ def _get_train_sampler(
         )
     else:
         sampler = DistributedSampler(
-            train_dataset, num_replicas=dl_ranks_size, rank=dl_rank, seed=seed, drop_last=drop_last
+            train_dataset, num_replicas=dl_ranks_size, rank=dl_rank, seed=seed, drop_last=drop_last, shuffle=shuffle
         )
 
     if consumed_train_samples > 0:
@@ -495,7 +493,7 @@ def get_train_dataloader(
     # TODO @nouamanetazi: Remove unused columns: https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/src/transformers/trainer.py#L852
     # TODO @nouamanetazi: Support torch.utils.data.IterableDataset: https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/src/transformers/trainer.py#L855-L872
 
-    train_sampler = _get_train_sampler(
+    train_sampler = get_sampler(
         dl_rank=dp_rank,
         dl_ranks_size=dp_ranks_size,
         train_dataset=train_dataset,

--- a/tests/helpers/data.py
+++ b/tests/helpers/data.py
@@ -45,7 +45,6 @@ def preprocess_dummy_dataset(path_to_json: str):
         column="text",
         output_prefix=path_to_json,
         tokenizer_name_or_path="openai-community/gpt2",
-        num_workers=int(min(os.cpu_count(), 4)),
         add_special_tokens=False,
     )
 

--- a/tests/helpers/data.py
+++ b/tests/helpers/data.py
@@ -1,0 +1,172 @@
+import hashlib
+import importlib
+import json
+import os
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+package = importlib.import_module("nanotron")
+package_path = Path(package.__file__).parent.parent.parent
+sys.path.append(str(package_path))
+
+from argparse import Namespace
+
+import nanotron.distributed as dist
+import torch
+from nanotron.data.nanoset import Nanoset
+from nanotron.parallel import ParallelContext
+from nanotron.parallel.pipeline_parallel.tensor_pointer import TensorPointer
+from nanotron.sanity_checks import assert_tensor_synced_across_pg
+
+from tools.preprocess_data import main
+
+
+def create_dataset_paths(tmp_dir: str, quantity: int):
+    json_dataset_path = [os.path.join(tmp_dir, f"pytest_{i}") for i in range(quantity)]
+    mmap_dataset_path = [f"{path}_input_ids.npy" for path in json_dataset_path]
+
+    return json_dataset_path, mmap_dataset_path
+
+
+def create_dummy_json_dataset(path_to_json: str, dummy_text: str, n_samples: int = 50000):
+
+    with open(path_to_json + ".json", "a") as json_file:
+        for sample in range(n_samples):
+            sample_dict = {"text": f"[{sample}] Hello! Im sample {sample}! And this is my dummy text: {dummy_text}"}
+            json_file.write(json.dumps(sample_dict))
+            json_file.write("\n")
+
+
+def preprocess_dummy_dataset(path_to_json: str):
+    # Create args for preprocessing
+    args = Namespace(
+        input=path_to_json + ".json",
+        column="text",
+        output_prefix=path_to_json,
+        tokenizer_name_or_path="openai-community/gpt2",
+        num_workers=int(min(os.cpu_count(), 4)),
+        add_special_tokens=False,
+    )
+
+    # tools/preprocess_data.py main
+    main(args)
+
+
+def assert_batch_dataloader(
+    batch: dict, parallel_context: ParallelContext, micro_batch_size: int, sequence_length: int
+):
+    """
+    batch (dict): Batch produced from the Dataloader, with keys input_ids, input_mask, label_ids, label_mask
+
+    """
+    for element in batch:
+        tensor = batch[element]
+
+        # Assert that inputs are only present in input_pp_rank and outputs in output_pp_rank
+        input_pp_rank, output_pp_rank = 0, int(parallel_context.pp_pg.size() - 1)
+        if dist.get_rank(parallel_context.pp_pg) == input_pp_rank and element.startswith("input_"):
+            assert isinstance(tensor, torch.Tensor)
+        elif dist.get_rank(parallel_context.pp_pg) == output_pp_rank and element.startswith("label_"):
+            assert isinstance(tensor, torch.Tensor)
+        else:
+            assert isinstance(tensor, TensorPointer)
+
+        data_class = (
+            0  # 0 if tensor is from the ids, 1 if TensorPointer and 2 if mask. Used in the data parallel group check
+        )
+
+        # Check shape of mask and ids tensors
+        if isinstance(tensor, torch.Tensor):
+            assert tensor.shape == (micro_batch_size, sequence_length)
+
+        # TensorPointer case: Check that all TensorPointers from the same tp_pg point to the same group_rank. Create torch.tensor with group_rank
+        if isinstance(tensor, TensorPointer):
+            tensor = torch.tensor(tensor.group_rank)
+            data_class = 1
+
+        # Attention Masks case: dtype is torch.bool --> Transform to int64
+        if tensor.dtype == torch.bool:
+            tensor = tensor.long()
+            data_class = 2
+
+        # Assert that we have the SAME element in all the processes belonging to the same tensor parallel group
+        assert_tensor_synced_across_pg(
+            tensor=tensor.flatten().cuda(),
+            pg=parallel_context.tp_pg,
+            msg=lambda err: f"{element} is not synchronized across TP {err}",
+        )
+
+        # Assert that we have the SAME class of data in all processes belonging to the same data parallel group
+        assert_tensor_synced_across_pg(
+            tensor=torch.tensor(data_class, device="cuda"),
+            pg=parallel_context.dp_pg,
+            msg=lambda err: f"{element} is not synchronized across DP {err}",
+        )
+
+
+def compute_hash(identifier: OrderedDict, n_digit: int = 8) -> int:
+    """
+    Creates a sha256 hash from the elements of a OrderedDict
+    """
+    unique_description = json.dumps(identifier, indent=4)
+    # Create n_digit description hash
+    unique_description_hash = int(hashlib.sha256(unique_description.encode("utf-8")).hexdigest(), 16) % 10**n_digit
+    return unique_description_hash
+
+
+def assert_nanoset_sync_across_all_ranks(nanoset: Nanoset, parallel_context: ParallelContext):
+    """
+    Checks that the same Nanoset is created in all processes
+    """
+    # Extract a sample from the Nanoset
+    IDX_SAMPLE = 23
+
+    nanoset_identifiers = OrderedDict()
+    nanoset_identifiers["dataset_paths"] = nanoset.dataset_paths
+    nanoset_identifiers["dataset_weights"] = nanoset.dataset_weights.tolist()
+    nanoset_identifiers["sequence_length"] = nanoset.sequence_length
+    nanoset_identifiers["train_split_num_samples"] = nanoset.train_split_num_samples
+    nanoset_identifiers["random_seed"] = nanoset.random_seed
+    nanoset_identifiers["length"] = len(nanoset)
+    nanoset_identifiers["input_ids"] = nanoset[IDX_SAMPLE]["input_ids"].tolist()
+    nanoset_identifiers["dataset_index"] = nanoset.dataset_index.tolist()
+    nanoset_identifiers["dataset_sample_index"] = nanoset.dataset_sample_index.tolist()
+
+    unique_description_hash = compute_hash(nanoset_identifiers)
+    assert_tensor_synced_across_pg(
+        tensor=torch.tensor(unique_description_hash, device="cuda"),
+        pg=parallel_context.world_pg,
+        msg=lambda err: f"Nanoset is not synchronized across all processes {err}",
+    )
+
+
+def compute_batch_hash(batch: dict) -> int:
+    """
+    Checks that the Nanoset/BlendedNanoset is in the same state after recovering from a crash
+
+    batch (dict): Batch produced from the Dataloader, with keys input_ids, input_mask, label_ids, label_mask
+
+    """
+    batch_identifiers = OrderedDict()
+
+    for element in batch:
+        tensor = batch[element]
+
+        # TensorPointer
+        if isinstance(tensor, TensorPointer):
+            identifier = tensor.group_rank
+
+        # Attention Masks case: dtype is torch.bool --> Transform to int64
+        elif tensor.dtype == torch.bool:
+            identifier = tensor.long().tolist()
+
+        # Input IDs tensor
+        else:
+            identifier = tensor.tolist()
+
+        batch_identifiers[element] = identifier
+
+    unique_description_hash = compute_hash(batch_identifiers)
+
+    return unique_description_hash

--- a/tests/helpers/data.py
+++ b/tests/helpers/data.py
@@ -38,13 +38,13 @@ def create_dummy_json_dataset(path_to_json: str, dummy_text: str, n_samples: int
             json_file.write("\n")
 
 
-def preprocess_dummy_dataset(path_to_json: str):
+def preprocess_dummy_dataset(path_to_json: str, tokenizer: str):
     # Create args for preprocessing
     args = Namespace(
         input=path_to_json + ".json",
         column="text",
         output_prefix=path_to_json,
-        tokenizer_name_or_path="openai-community/gpt2",
+        tokenizer_name_or_path=tokenizer,
         add_special_tokens=False,
     )
 

--- a/tests/test_build_nanoset_dataloader.py
+++ b/tests/test_build_nanoset_dataloader.py
@@ -40,11 +40,8 @@ def test_build_nanoset_dataloader(tp: int, dp: int, pp: int, train_steps: int, s
     for idx, json_path in enumerate(json_paths):
         create_dummy_json_dataset(path_to_json=json_path, dummy_text=f"Nanoset {idx}!", n_samples=(idx + 1) * 50000)
 
-    # Preprocess dummy json datasets
-    for json_path in json_paths:
-        preprocess_dummy_dataset(path_to_json=json_path)
-
     init_distributed(tp=tp, dp=dp, pp=pp)(_test_build_nanoset_dataloader)(
+        json_paths=json_paths,
         path_to_mmap_files=mmap_dataset_paths,
         train_steps=train_steps,
         sequence_length=sequence_length,
@@ -53,6 +50,7 @@ def test_build_nanoset_dataloader(tp: int, dp: int, pp: int, train_steps: int, s
 
 def _test_build_nanoset_dataloader(
     parallel_context: ParallelContext,
+    json_paths: str,
     path_to_mmap_files: str,
     train_steps: int,
     sequence_length: int,
@@ -61,6 +59,10 @@ def _test_build_nanoset_dataloader(
     MICRO_BATCH_SIZE = 4
     N_MICRO_BATCHES_PER_BATCH = 8
     GLOBAL_BATCH_SIZE = MICRO_BATCH_SIZE * N_MICRO_BATCHES_PER_BATCH * parallel_context.dp_pg.size()
+
+    # Preprocess dummy json datasets
+    for json_path in json_paths:
+        preprocess_dummy_dataset(path_to_json=json_path)
 
     input_pp_rank, output_pp_rank = 0, int(parallel_context.pp_pg.size() - 1)
 
@@ -153,11 +155,8 @@ def test_recover_nanoset_dataloader(tp: int, dp: int, pp: int, skipped_batches: 
     for idx, json_path in enumerate(json_paths):
         create_dummy_json_dataset(path_to_json=json_path, dummy_text=f"Nanoset {idx}!", n_samples=(idx + 1) * 50000)
 
-    # Preprocess dummy json datasets
-    for json_path in json_paths:
-        preprocess_dummy_dataset(path_to_json=json_path)
-
     init_distributed(tp=tp, dp=dp, pp=pp)(_test_recover_nanoset_dataloader)(
+        json_paths=json_paths,
         path_to_mmap_files=mmap_dataset_paths,
         skipped_batches=skipped_batches,
     )
@@ -165,6 +164,7 @@ def test_recover_nanoset_dataloader(tp: int, dp: int, pp: int, skipped_batches: 
 
 def _test_recover_nanoset_dataloader(
     parallel_context: ParallelContext,
+    json_paths: str,
     path_to_mmap_files: str,
     skipped_batches: int,
 ):
@@ -174,6 +174,10 @@ def _test_recover_nanoset_dataloader(
     GLOBAL_BATCH_SIZE = MICRO_BATCH_SIZE * N_MICRO_BATCHES_PER_BATCH * parallel_context.dp_pg.size()
     SEQUENCE_LENGTH = 1024
     TRAIN_STEPS = 100
+
+    # Preprocess dummy json datasets
+    for json_path in json_paths:
+        preprocess_dummy_dataset(path_to_json=json_path)
 
     input_pp_rank, output_pp_rank = 0, int(parallel_context.pp_pg.size() - 1)
 

--- a/tests/test_build_nanoset_dataloader.py
+++ b/tests/test_build_nanoset_dataloader.py
@@ -1,0 +1,240 @@
+import numpy as np
+import pytest
+from helpers.context import TestContext
+from helpers.data import (
+    assert_batch_dataloader,
+    assert_nanoset_sync_across_all_ranks,
+    compute_batch_hash,
+    create_dataset_paths,
+    create_dummy_json_dataset,
+    preprocess_dummy_dataset,
+)
+from helpers.utils import available_gpus, get_all_3d_configurations, init_distributed, rerun_if_address_is_in_use
+from nanotron.data.dataloader_builder import build_nanoset_dataloader
+from nanotron.data.nanoset import Nanoset
+from nanotron.parallel import ParallelContext
+from nanotron.utils import main_rank_first
+
+
+@pytest.mark.parametrize(
+    "tp,dp,pp",
+    [
+        pytest.param(*all_3d_configs)
+        for gpus in range(1, min(available_gpus(), 4) + 1)
+        for all_3d_configs in get_all_3d_configurations(gpus)
+    ],
+)
+@pytest.mark.parametrize("train_steps", [5, 100])
+@pytest.mark.parametrize("sequence_length", [512, 8192])
+@rerun_if_address_is_in_use()
+def test_build_nanoset_dataloader(tp: int, dp: int, pp: int, train_steps: int, sequence_length: int):
+    test_context = TestContext()
+
+    # Create dataset files
+    json_paths, mmap_dataset_paths = create_dataset_paths(tmp_dir=test_context.get_auto_remove_tmp_dir(), quantity=2)
+
+    # Create dummy json datasets
+    for idx, json_path in enumerate(json_paths):
+        create_dummy_json_dataset(path_to_json=json_path, dummy_text=f"Nanoset {idx}!", n_samples=(idx + 1) * 50000)
+
+    # Preprocess dummy json datasets
+    for json_path in json_paths:
+        preprocess_dummy_dataset(path_to_json=json_path)
+
+    init_distributed(tp=tp, dp=dp, pp=pp)(_test_build_nanoset_dataloader)(
+        path_to_mmap_files=mmap_dataset_paths,
+        train_steps=train_steps,
+        sequence_length=sequence_length,
+    )
+
+
+def _test_build_nanoset_dataloader(
+    parallel_context: ParallelContext,
+    path_to_mmap_files: str,
+    train_steps: int,
+    sequence_length: int,
+):
+    SEED = 1234
+    MICRO_BATCH_SIZE = 4
+    N_MICRO_BATCHES_PER_BATCH = 8
+    GLOBAL_BATCH_SIZE = MICRO_BATCH_SIZE * N_MICRO_BATCHES_PER_BATCH * parallel_context.dp_pg.size()
+
+    input_pp_rank, output_pp_rank = 0, int(parallel_context.pp_pg.size() - 1)
+
+    # Create Nanoset configs: 1. Normal 2. Blended 3. Blended with weights
+    nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0]],
+        "dataset_weights": [1],
+        "sequence_length": sequence_length,
+        "train_split_num_samples": train_steps * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    blended_nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0], path_to_mmap_files[1]],
+        "dataset_weights": None,
+        "sequence_length": sequence_length,
+        "train_split_num_samples": train_steps * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    blended_weighted_nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0], path_to_mmap_files[1]],
+        "dataset_weights": [8, 2],
+        "sequence_length": sequence_length,
+        "train_split_num_samples": train_steps * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    configs = [nanoset_config, blended_nanoset_config, blended_weighted_nanoset_config]
+
+    for config in configs:
+        # Create Nanoset
+        with main_rank_first(parallel_context.world_pg):
+            train_dataset = Nanoset(**config)
+
+        # Assert we have the same Nanoset in all ranks
+        assert_nanoset_sync_across_all_ranks(train_dataset, parallel_context)
+        # Assert Nanoset doesn't sample indexes greater than the datasets
+        for idx, ds_length in enumerate(train_dataset.dataset_lengths):
+            assert (
+                np.max(train_dataset.dataset_sample_index, where=train_dataset.dataset_index == idx, initial=-1)
+                < ds_length
+            ), f"Error building Nanoset Indexes: Tryng to access sample {np.max(train_dataset.dataset_sample_index, where=train_dataset.dataset_index==idx, initial = -1)} of a {ds_length} sample dataset"
+
+        # Create Dataloaders
+        dataloader = build_nanoset_dataloader(
+            train_dataset,
+            sequence_length=sequence_length,
+            parallel_context=parallel_context,
+            input_pp_rank=input_pp_rank,
+            output_pp_rank=output_pp_rank,
+            micro_batch_size=MICRO_BATCH_SIZE,
+            dataloader_num_workers=0,
+            dataloader_drop_last=True,
+        )
+
+        # Check a batch produced by the Dataloader
+        batch = next(iter(dataloader))
+        assert_batch_dataloader(
+            batch=batch,
+            parallel_context=parallel_context,
+            micro_batch_size=MICRO_BATCH_SIZE,
+            sequence_length=sequence_length,
+        )
+
+    parallel_context.destroy()
+
+
+@pytest.mark.parametrize(
+    "tp,dp,pp",
+    [
+        pytest.param(*all_3d_configs)
+        for gpus in range(1, min(available_gpus(), 4) + 1)
+        for all_3d_configs in get_all_3d_configurations(gpus)
+    ],
+)
+@pytest.mark.parametrize("skipped_batches", [20, 50])
+@rerun_if_address_is_in_use()
+def test_recover_nanoset_dataloader(tp: int, dp: int, pp: int, skipped_batches: int):
+    test_context = TestContext()
+
+    # Create dataset files
+    json_paths, mmap_dataset_paths = create_dataset_paths(tmp_dir=test_context.get_auto_remove_tmp_dir(), quantity=2)
+
+    # Create dummy json datasets
+    for idx, json_path in enumerate(json_paths):
+        create_dummy_json_dataset(path_to_json=json_path, dummy_text=f"Nanoset {idx}!", n_samples=(idx + 1) * 50000)
+
+    # Preprocess dummy json datasets
+    for json_path in json_paths:
+        preprocess_dummy_dataset(path_to_json=json_path)
+
+    init_distributed(tp=tp, dp=dp, pp=pp)(_test_recover_nanoset_dataloader)(
+        path_to_mmap_files=mmap_dataset_paths,
+        skipped_batches=skipped_batches,
+    )
+
+
+def _test_recover_nanoset_dataloader(
+    parallel_context: ParallelContext,
+    path_to_mmap_files: str,
+    skipped_batches: int,
+):
+    SEED = 1234
+    MICRO_BATCH_SIZE = 4
+    N_MICRO_BATCHES_PER_BATCH = 8
+    GLOBAL_BATCH_SIZE = MICRO_BATCH_SIZE * N_MICRO_BATCHES_PER_BATCH * parallel_context.dp_pg.size()
+    SEQUENCE_LENGTH = 1024
+    TRAIN_STEPS = 100
+
+    input_pp_rank, output_pp_rank = 0, int(parallel_context.pp_pg.size() - 1)
+
+    # Create Nanoset configs: 1. Normal 2. Blended 3. Blended with weights
+    nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0]],
+        "dataset_weights": [1],
+        "sequence_length": SEQUENCE_LENGTH,
+        "train_split_num_samples": TRAIN_STEPS * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    blended_nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0], path_to_mmap_files[1]],
+        "dataset_weights": None,
+        "sequence_length": SEQUENCE_LENGTH,
+        "train_split_num_samples": TRAIN_STEPS * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    blended_weighted_nanoset_config = {
+        "dataset_paths": [path_to_mmap_files[0], path_to_mmap_files[1]],
+        "dataset_weights": [8, 2],
+        "sequence_length": SEQUENCE_LENGTH,
+        "train_split_num_samples": TRAIN_STEPS * GLOBAL_BATCH_SIZE,
+        "random_seed": SEED,
+    }
+
+    configs = [nanoset_config, blended_nanoset_config, blended_weighted_nanoset_config]
+
+    for config in configs:
+        # Create Nanoset
+        with main_rank_first(parallel_context.world_pg):
+            train_dataset = Nanoset(**config)
+
+        # Create initial Dataloader
+        dataloader = build_nanoset_dataloader(
+            train_dataset,
+            sequence_length=SEQUENCE_LENGTH,
+            parallel_context=parallel_context,
+            input_pp_rank=input_pp_rank,
+            output_pp_rank=output_pp_rank,
+            micro_batch_size=MICRO_BATCH_SIZE,
+            dataloader_num_workers=0,
+            dataloader_drop_last=True,
+        )
+
+        # Recover from failures
+        dataloader = iter(dataloader)
+        for _ in range(skipped_batches + 1):  # In order to compare with the first batch of the recovered DataLoader
+            batch = next(dataloader)
+
+        # Create recover Dataloader
+        recovered_dataloader = build_nanoset_dataloader(
+            train_dataset,
+            sequence_length=SEQUENCE_LENGTH,
+            parallel_context=parallel_context,
+            input_pp_rank=input_pp_rank,
+            output_pp_rank=output_pp_rank,
+            micro_batch_size=MICRO_BATCH_SIZE,
+            dataloader_num_workers=0,
+            dataloader_drop_last=True,
+            # NOTE The dataloader serves batches of micro_batch_size despite of batch_accumulation_per_replica
+            consumed_train_samples=skipped_batches * MICRO_BATCH_SIZE * parallel_context.dp_pg.size(),
+        )
+
+        recovered_first_batch = next(iter(recovered_dataloader))
+
+        assert compute_batch_hash(batch) == compute_batch_hash(recovered_first_batch)
+
+    parallel_context.destroy()

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -1,0 +1,124 @@
+import argparse
+import multiprocessing
+import os
+import shutil
+
+import numpy as np
+from tqdm import tqdm
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from datasets import Dataset, concatenate_datasets, load_dataset
+
+
+def preprocess_shard(
+    dataset_shard: Dataset, output_file: str, tokenizer: PreTrainedTokenizerBase, column: str, add_special_tokens: bool
+):
+    dataset_shard = dataset_shard.map(
+        lambda x: {"input_ids": tokenizer(x, add_special_tokens=add_special_tokens).input_ids},
+        input_columns=column,
+        batched=True,
+        desc="Tokenizing Dataset",
+        remove_columns=[column],
+    )
+    input_ids_file = open(output_file, "wb")
+    for sample in dataset_shard:
+        np_array = np.array(sample["input_ids"], dtype=np.uint16)
+        input_ids_file.write(np_array.tobytes(order="C"))
+    input_ids_file.close()
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="input data")
+    group.add_argument(
+        "--input", type=str, required=True, help="Path to local stored dataset or repository on the Hugging Face hub"
+    )
+    group.add_argument("--column", type=str, default="text", help="Column to preprocess from the Dataset")
+    parser.add_argument("--split", type=str, default="train", help="Which split of the data to process")
+
+    group = parser.add_argument_group(title="tokenizer")
+    group.add_argument(
+        "--tokenizer-name-or-path",
+        type=str,
+        required=True,
+        help="A path to a directory containing vocabulary files required by the tokenizer or the model id of a predefined tokenizer hosted inside a model repo on the Hugging Face Hub.",
+    )
+    group.add_argument(
+        "--add-special-tokens",
+        action="store_true",
+        help="Whether or not to add special tokens when encoding the sequences. This will be passed to the Tokenizer",
+    )
+
+    group = parser.add_argument_group(title="output data")
+    group.add_argument("--output-prefix", type=str, required=True, help="Path to the output processed dataset file")
+
+    group = parser.add_argument_group(title="runtime")
+    group.add_argument("--num-workers", type=int, default=8, help="Number of workers processing the dataset")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+
+    # Check if output directory exists
+    if not os.path.isdir(os.path.abspath(os.path.join(args.output_prefix, os.path.pardir))):
+        print(f"Creating {os.path.abspath(os.path.join(args.output_prefix, os.path.pardir))} directory...")
+        os.makedirs(os.path.abspath(os.path.join(args.output_prefix, os.path.pardir)), exist_ok=True)
+
+    if args.input.endswith(".json"):  # For processing JSON files (Cross compatibility with other projects)
+        ds = load_dataset("json", data_files=args.input)
+        ds = concatenate_datasets(
+            [ds[splits] for splits in ds.keys()]
+        )  # load_dataset returns DatasetDict and we want a Dataset
+    else:
+        ds = load_dataset(args.input, split=args.split, num_proc=args.num_workers)
+
+    ds = ds.select_columns(args.column)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name_or_path)
+
+    # Create tmp directory for worker outputs
+    tmp_folder = os.path.abspath(os.path.join(args.output_prefix, os.pardir, "tmp"))
+    os.makedirs(tmp_folder, exist_ok=True)
+    workers_output_files = []
+    processes = []
+
+    print("Creating worker output files...")
+    for worker in range(args.num_workers):
+        worker_output_file = os.path.join(tmp_folder, f"worker_{worker}_input_ids.npy")
+        workers_output_files.append(worker_output_file)
+
+        p = multiprocessing.Process(
+            target=preprocess_shard,
+            args=(
+                ds.shard(num_shards=args.num_workers, index=worker, contiguous=True),
+                worker_output_file,
+                tokenizer,
+                args.column,
+                args.add_special_tokens,
+            ),
+        )
+
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join()
+
+    output_file = f"{args.output_prefix}_input_ids.npy"
+    input_ids_file = open(output_file, "wb")
+    for worker_output_file in tqdm(workers_output_files, desc="Merging worker output files"):
+        with open(worker_output_file, "rb") as f:
+            shutil.copyfileobj(f, input_ids_file)
+        os.remove(worker_output_file)
+
+    input_ids_file.close()
+    os.rmdir(tmp_folder)
+    print(f"Done! {args.input} processed dataset stored in {output_file}")
+
+
+if __name__ == "__main__":
+    _args = get_args()
+    main(_args)

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -66,6 +66,7 @@ def main(args):
     ds = ds.select_columns(args.column)
 
     tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name_or_path)
+    token_dtype = np.int32 if len(tokenizer) > np.iinfo(np.uint16).max + 1 else np.uint16
 
     # Create tmp directory for worker outputs
     tmp_folder = os.path.abspath(os.path.join(args.output_prefix, os.pardir, "tmp"))
@@ -83,7 +84,7 @@ def main(args):
 
     worker_input_ids_file = open(worker_output_file, "wb")
     for sample in ds:
-        np_array = np.array(sample["input_ids"], dtype=np.uint16)
+        np_array = np.array(sample["input_ids"], dtype=token_dtype)
         worker_input_ids_file.write(np_array.tobytes(order="C"))
     worker_input_ids_file.close()
 


### PR DESCRIPTION
Hi!

After all your comments in the previous [PR](https://github.com/huggingface/nanotron/pull/102), I decided to give one last (big) overhaul to the Nanosets, and I think now we can indeed call them Nanosets. In short, I completely got rid of the `NanosetBuilder`, `NanosetConfig`, `BlendedNanoset`, and `MMapIndexedDataset`. Also, I got rid of the different Nanosets for each train, valid, and test split (I've seen code snippets where you mention that you intend to support this, so when the time comes, I'll include it). Now there are ONLY the `Nanosets`, for which we ONLY have to specify the paths to the preprocessed datasets and, if we want, a weight for each one.

Basically, for each `dataset_path` specified in the configuration, we will read the `total number of tokens` and divide it by the `sequence length` to know the `number of samples` we can construct. If we have more than one dataset and do not specify the weight for each of them, we will consume them entirely for each epoch. Otherwise, we will build the `Nanoset` respecting these weights, consuming samples from the datasets again if necessary (i.e., if we need 1000 training samples and the weight of dataset 1 is 0.9, we will need 900 samples from this dataset. If dataset 1 only has 100 samples, we will consume it 9 times per epoch).

To determine from which dataset within the `Nanoset` and which sample to extract, we will build two indices: `dataset_index`, which will select the dataset from which to extract the sample, and `dataset_sample_index`, which will select the sample from the dataset. These two indices will be constructed using a helper function ([`build_nanoset_index_helper`](https://github.com/huggingface/nanotron/blob/e32b0799ea50dc365cf6d10eafe67ffd436e5c04/src/nanotron/data/nanoset.py#L152)) that we will compile with Numba. This function is similar to the ones included in Megatron, which were compiled in C++, but in Python, for very large datasets, it took an enormous amount of time to run. Now with Numba, we solve this problem, keeping the entire project in Python. With these two indices, we will access the specific dataset and extract the sample with `sequence length + 1` tokens.

I have updated the documentation by adding a detailed explanation of how they work, although I have left many comments in [`nanoset.py`](https://github.com/huggingface/nanotron/blob/e32b0799ea50dc365cf6d10eafe67ffd436e5c04/src/nanotron/data/nanoset.py#L13). I have also updated the tests, checking the following:
1. That we build the same `Nanoset` in ALL processes.
2. That `dataset_index` has been constructed according to the `dataset_weights`.
3. That `dataset_sample_index` does not attempt to extract samples > `len(dataset)`. 

To install the necessary dependencies, I have created a new flavor of Nanotron, so it will be necessary to install it with `pip install -e '.[nanosets]'`. You can test them as follows with the [config](https://github.com/huggingface/nanotron/blob/e32b0799ea50dc365cf6d10eafe67ffd436e5c04/examples/config_nanoset.yaml) I have added:
```sh
python3 tools/preprocess_data.py \
       --input yelp_review_full \
       --split train \
       --output-prefix datasets/yelp_review_full \
       --tokenizer-name-or-path gpt2 \
       --num-workers 16
```

```sh
python3 tools/preprocess_data.py \
       --input HuggingFaceH4/testing_alpaca_small \
       --split train \
       --column completion \
       --output-prefix datasets/testing_alpaca_small \
       --tokenizer-name-or-path gpt2 \
       --num-workers 16
```

We launch the job with:

```sh
torchrun --nproc-per-node 4 run_train.py --config examples/config_nanoset.yaml
```

I have tested it with a setup with 4 GPUs.

As always, I expect your comments!

Toni.