### PR TITLE
Fix TestContext warning

### DIFF
--- a/tests/helpers/context.py
+++ b/tests/helpers/context.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 
 class TestContext:
+    __test__ = False
+
     def __init__(self):
         self._random_string = str(uuid.uuid1())
         self._root_dir = Path(__file__).parent.parent / ".test_cache"


### PR DESCRIPTION
When you run any test that uses `TestContext` you will get some warnings like this:
```
====================================================================== warnings summary ======================================================================
tests/helpers/context.py:7: 35 warnings                                        
  /mloscratch/homes/alhernan/project/workspace/nanotron/tests/helpers/context.py:7: PytestCollectionWarning: cannot collect test class 'TestContext' because i
t has a __init__ constructor (from: test_serialize.py)                         
    class TestContext:                                                         
                                                                               
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html                                                                                       
======================================================== 19 passed, 8 skipped, 35 warnings in 25.47s =========================================================
```

This can be easily fixed by setting `__test__ = False` in the `TestContext` class. This PR fixes those warnings.