### PR TITLE
Enable masking when tp=1

### DIFF
--- a/src/nanotron/parallel/tensor_parallel/nn.py
+++ b/src/nanotron/parallel/tensor_parallel/nn.py
@@ -272,15 +272,12 @@ class TensorParallelEmbedding(nn.Embedding):
         mark_all_parameters_in_module_as_sharded(self, pg=self.pg, split_config=split_config)
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
-        if self.pg.size() > 1:
-            # `0` if input is in the correct interval, else `1`
-            input_mask = torch.logical_or(self.min_id > input_ids, input_ids >= self.max_id)
-            # translate for [0, self.max_id - self.min_id[
-            masked_input = input_ids.clone() - self.min_id
-            # default all out of bounds values to `0`
-            masked_input[input_mask] = 0
-        else:
-            masked_input = input_ids
+        # `0` if input is in the correct interval, else `1`
+        input_mask = torch.logical_or(self.min_id > input_ids, input_ids >= self.max_id)
+        # translate for [0, self.max_id - self.min_id[
+        masked_input = input_ids.clone() - self.min_id
+        # default all out of bounds values to `0`
+        masked_input[input_mask] = 0
         out = super().forward(masked_input)
 
         if self.pg.size() > 1:


### PR DESCRIPTION
In the config_tiny_llama.py example, the model's vocab_size is 256, while the GPT-2 tokenizer's vocabulary size is 50257. This incompatibility is avoided by masking when tp>1, but will cause an error when tp=1. Therefore, this PR ensure that masking is also enabled when tp=1.