### PR TITLE
Fixed FA2 test

### DIFF
--- a/.github/workflows/fa2_unit_tests.yaml
+++ b/.github/workflows/fa2_unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
         python -c "import torch; print('torch:', torch.__version__, torch)"
         python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-    - name: Instal nanotron
+    - name: Install nanotron
       run: |
         python -m pip install --upgrade pip
         pip install packaging
@@ -55,4 +55,4 @@ jobs:
     - name: Run tests
       # NOTE: -m fa2 will only run the unit tests that have the mark
       # "fa2" (these are FA2-related tests)
-      run: pytest -m fa2 --color=yes --durations=0 --ignore tests/fp8 --verbose tests/
+      run: pytest -m fa2 --color=yes --durations=0 --ignore tests/fp8 --ignore tests/nanoset --verbose tests/

--- a/tests/nanoset/test_build_nanoset_dataloader.py
+++ b/tests/nanoset/test_build_nanoset_dataloader.py
@@ -1,4 +1,9 @@
+import sys
 from math import isclose
+from pathlib import Path
+
+package_path = Path(__file__).parent.parent
+sys.path.append(str(package_path))
 
 import numpy as np
 import pytest


### PR DESCRIPTION
Moved `Nanoset` tests to a specific folder in order to ignore them in fa2_unit_tests. Other solution will be to install the Nanosets flavour in fa2_unit_tests.