### PR TITLE
Fix _RowLinearAsyncCommunication

### DIFF
--- a/.github/workflows/fa2_unit_tests.yaml
+++ b/.github/workflows/fa2_unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
         python -c "import torch; print('torch:', torch.__version__, torch)"
         python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-    - name: Instal nanotron
+    - name: Install nanotron
       run: |
         python -m pip install --upgrade pip
         pip install packaging
@@ -55,4 +55,4 @@ jobs:
     - name: Run tests
       # NOTE: -m fa2 will only run the unit tests that have the mark
       # "fa2" (these are FA2-related tests)
-      run: pytest -m fa2 --color=yes --durations=0 --ignore tests/fp8 --verbose tests/
+      run: pytest -m fa2 --color=yes --durations=0 --ignore tests/fp8 --ignore tests/nanoset --verbose tests/

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+
+name: Secret Leaks
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Secret Scanning
+      uses: trufflesecurity/trufflehog@main

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,9 @@ test:
         --ignore tests/fp8 \
         --verbose \
         examples/doremi/tests/
+
+	pip install -r examples/llama/requirements.txt
+	pytest \
+        --color=yes \
+        --verbose \
+        examples/llama/tests/

--- a/examples/llama/README.md
+++ b/examples/llama/README.md
@@ -1,0 +1,17 @@
+## Debugging the tests with vscode
+
+To debug the tests with vscode, add the following json to your `launch.json` file.
+
+```
+{
+    "name": "Test conversion",
+    "type": "python",
+        "request": "launch",
+        "module": "pytest",
+        "console": "integratedTerminal",
+        "args": [
+            "examples/llama/tests"
+        ],
+        "justMyCode": false
+}
+```

--- a/examples/llama/convert_hf_to_nanotron.py
+++ b/examples/llama/convert_hf_to_nanotron.py
@@ -1,0 +1,119 @@
+"""
+Converts a HF model to nanotron format
+Command:
+    torchrun --nproc_per_node=1 convert_hf_to_nanotron.py --checkpoint_path=hf_weights --save_path=nanotron_weights
+"""
+
+import dataclasses
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+
+import nanotron
+import torch
+from convert_weights import get_config_mapping, get_weight_mapping, load_nanotron_model
+from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.models.llama import LlamaForTraining
+from transformers import LlamaConfig as HFLlamaConfig
+from transformers import LlamaForCausalLM
+
+
+def _handle_attention_block(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, n_q_heads: int, n_kv_heads: int, d_qk: int
+) -> torch.Tensor:
+    # Huggingface Llama separates the q, k, v weights (as opposed to nanotron).
+    # Furthermore, in the rotary embeddings in nanotron expects interleaved pairs of even
+    # and odd dimensions GPT-J style, while the huggingface implementation expects
+    # the whole 1st half and then the whole 2nd half GPT-NeoX style (for more information
+    # see flash_attn.layers.rotary.RotaryEmbedding).
+    # This function handles the concatenation of the q, k, v weights and proper permutation
+    # to ensure correct transformation.
+
+    def interleave(w: torch.Tensor):
+        w_new = []
+        for head_w in w.split(d_qk):
+            head_w = head_w.view(2, d_qk // 2, -1).transpose(0, 1).reshape(d_qk, -1)
+            w_new.append(head_w)
+        return torch.cat(w_new)
+
+    q = interleave(q)
+    k = interleave(k)
+    return torch.cat([q, k, v])
+
+
+def convert_hf_to_nt(model_hf: LlamaForCausalLM, model_nt: LlamaForTraining, config: NanotronLlamaConfig):
+    """Converts the weights from the model_hf to model_nt, making modifications
+    in-place."""
+
+    hf_sd = model_hf.state_dict()
+    nt_to_hf = get_weight_mapping(config, nt_to_hf=True)
+
+    for module_name_nt, module_nt in model_nt.named_modules():
+        for param_name_nt, param_nt in module_nt.named_parameters(recurse=False):
+            # In the case of qkv_proj, the nt_to_hf has exactly three keys, ccorresponding
+            # to q, k, v.
+            if "qkv_proj" in module_name_nt:
+                key_k, key_q, key_v = sorted(nt_to_hf[f"{module_name_nt}.{param_name_nt}"])
+                q = hf_sd[key_q]
+                k = hf_sd[key_k]
+                v = hf_sd[key_v]
+                param = _handle_attention_block(
+                    q,
+                    k,
+                    v,
+                    config.num_attention_heads,
+                    config.num_key_value_heads,
+                    config.hidden_size // config.num_attention_heads,
+                )
+            # The case of gate_up_proj, nt_to_hf_map has two keys.
+            elif "gate_up_proj" in module_name_nt:
+                key_gate, key_up = sorted(nt_to_hf[f"{module_name_nt}.{param_name_nt}"])
+                gate = hf_sd[key_gate]
+                up = hf_sd[key_up]
+                param = torch.cat([gate, up])
+            # All other cases are simple 1-to-1 correspondence.
+            else:
+                hf_key = nt_to_hf[f"{module_name_nt}.{param_name_nt}"]
+                param = hf_sd[hf_key]
+
+            with torch.no_grad():
+                param_nt.copy_(param)
+
+
+def get_nanotron_config(config: HFLlamaConfig) -> NanotronLlamaConfig:
+    """Converts a huggingface configuration to nanotron configuration."""
+    attrs = {key: getattr(config, value) for key, value in get_config_mapping(nt_to_hf=True).items()}
+    return NanotronLlamaConfig(**attrs)
+
+
+def convert_checkpoint_and_save(checkpoint_path: Path, save_path: Path):
+    """Loads the huggingface checkpoint in `checkpoint_path`, creates
+    a new nanotron instance, copies the weights from the huggingface checkpoint
+    and saves the transformed nanotron to `save_path`."""
+
+    # Load huggingface.
+    hf_model = LlamaForCausalLM.from_pretrained(checkpoint_path)
+
+    # Init nanotron model.
+    model_config = get_nanotron_config(hf_model.config)
+    nanotron_model = load_nanotron_model(model_config=model_config)
+
+    # Copy weights and save model.
+    parallel_context = nanotron.parallel.ParallelContext(
+        data_parallel_size=1, pipeline_parallel_size=1, tensor_parallel_size=1
+    )
+    convert_hf_to_nt(hf_model, nanotron_model, model_config)
+    nanotron.serialize.save_weights(model=nanotron_model, parallel_context=parallel_context, root_folder=save_path)
+    with open(save_path / "model_config.json", "w+") as f:
+        json.dump(dataclasses.asdict(model_config), f)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Convert HF weights to nanotron format")
+    parser.add_argument("--checkpoint_path", type=Path, default="llama-7b", help="Path to the checkpoint")
+    parser.add_argument("--save_path", type=Path, default="llama-7b-hf", help="Path to save the nanotron model")
+    args = parser.parse_args()
+
+    # Convert HF model to nanotron format.
+    convert_checkpoint_and_save(checkpoint_path=args.checkpoint_path, save_path=args.save_path)

--- a/examples/llama/convert_nanotron_to_hf.py
+++ b/examples/llama/convert_nanotron_to_hf.py
@@ -1,0 +1,154 @@
+"""
+Converts a nanotron model to HF format
+Command:
+    torchrun --nproc_per_node=1 convert_nanotron_to_hf.py --checkpoint_path=nanotron-path --save_path=hf-path
+"""
+
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Literal, Optional
+
+import torch
+from convert_weights import get_config_mapping, get_weight_mapping, load_nanotron_model
+from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.models import init_on_device_and_dtype
+from nanotron.models.llama import LlamaForTraining
+from transformers import AutoTokenizer, LlamaForCausalLM
+from transformers import LlamaConfig as HFLlamaConfig
+
+TEST_PROMPT = "What is the meaning of the word chutzpah?\nThe word chutzpah means"
+
+
+def _handle_attention_block(
+    qkv: torch.Tensor, part: Literal["q", "k", "v"], n_q_heads: int, n_kv_heads: int, d_qk: int
+) -> torch.Tensor:
+    # Huggingface Llama separates the q, k, v weights (as opposed to nanotron).
+    # Furthermore, in the rotary embeddings in nanotron expects interleaved pairs of even
+    # and odd dimensions GPT-J style, while the huggingface implementation expects
+    # the whole 1st half and then the whole 2nd half GPT-NeoX style (for more information
+    # see flash_attn.layers.rotary.RotaryEmbedding).
+    # This function selects the proper chunk of the bundled qkv tensor and permutation
+    # to ensure correct transformation to huggingface.
+
+    def interleave(w: torch.Tensor):
+        w_new = []
+        for head_w in w.split(d_qk):
+            head_w = head_w.view(d_qk // 2, 2, -1).transpose(0, 1).reshape(d_qk, -1)
+            w_new.append(head_w)
+        return torch.cat(w_new)
+
+    assert part in ["q", "k", "v"], "part must be one of [q, k, v]"
+
+    index_end_q = n_q_heads * d_qk
+    index_end_k = index_end_q + n_kv_heads * d_qk
+    if part == "q":
+        return interleave(qkv[:index_end_q])
+    if part == "k":
+        return interleave(qkv[index_end_q:index_end_k])
+    return qkv[index_end_k:]
+
+
+def _handle_gate_up_proj(gate_up_proj: torch.Tensor, gate: bool) -> torch.Tensor:
+    # The gate and up projection are bundled in nanotron.
+    # This function selects the proper chunk in the bundled weights to return
+    # either the gate or the up projection only.
+    weight_size = gate_up_proj.shape[0] // 2
+    if gate:
+        return gate_up_proj[:weight_size]
+    else:
+        return gate_up_proj[weight_size:]
+
+
+def convert_nt_to_hf(nanotron_model: LlamaForTraining, hf_model: LlamaForCausalLM, model_config: NanotronLlamaConfig):
+    """Converts the weights from the nanotron_model to hf_model, making modifications
+    in-place."""
+
+    nanotron_model_state_dict = nanotron_model.state_dict()
+
+    hf_to_nt = get_weight_mapping(model_config, nt_to_hf=False)
+    for module_name_hf, module_hf in hf_model.named_modules():
+        for param_name_hf, param_hf in module_hf.named_parameters(recurse=False):
+            # Get the Nanotron parameter
+            nanotron_key = hf_to_nt[f"{module_name_hf}.{param_name_hf}"]
+            param = nanotron_model_state_dict[nanotron_key]
+
+            if "qkv_proj" in nanotron_key:
+                proj_name = module_name_hf.split(".")[4][0]
+                param = _handle_attention_block(
+                    param,
+                    proj_name,
+                    model_config.num_attention_heads,
+                    model_config.num_key_value_heads,
+                    model_config.hidden_size // model_config.num_attention_heads,
+                )
+
+            elif "gate_up_proj" in nanotron_key:
+                gate = "gate" in module_name_hf
+                param = _handle_gate_up_proj(param, gate)
+
+            with torch.no_grad():
+                param_hf.copy_(param)
+
+
+def get_hf_config(config: NanotronLlamaConfig) -> HFLlamaConfig:
+    """Converts a nanotron configuration to huggingface configuration."""
+    attrs = {key: getattr(config, value) for key, value in get_config_mapping(nt_to_hf=False).items()}
+    return HFLlamaConfig(**attrs)
+
+
+def convert_checkpoint_and_save(checkpoint_path: Path, save_path: Path, tokenizer_name: Optional[str] = None):
+    """Loads the nanotron checkpoint in `checkpoint_path`, creates
+    a new huggingface instance, copies the weights from the nanotron checkpoint
+    and saves the transformed huggingface to `save_path`."""
+
+    # Init nanotron model.
+    with open(checkpoint_path / "model_config.json", "r") as f:
+        attrs = json.load(f)
+        model_config = NanotronLlamaConfig(**attrs)
+    nanotron_model = load_nanotron_model(
+        model_config=model_config,
+        checkpoint_path=checkpoint_path,
+    )
+    # Init huggingface model.
+    with init_on_device_and_dtype(torch.device("cuda"), torch.bfloat16):
+        model_config_hf = get_hf_config(model_config)
+        hf_model = LlamaForCausalLM._from_config(model_config_hf)
+
+    # Copy weights, initialize tokenizer and save model.
+    if tokenizer_name is not None:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        tokenizer.save_pretrained(save_path)
+    convert_nt_to_hf(nanotron_model, hf_model, model_config)
+    hf_model.save_pretrained(save_path)
+    print(f"Model saved to {save_path}")
+
+
+def check_converted_model_generation(save_path: Path):
+    """Loads a huggingface model and tokenizer from `save_path` and
+    performs a dummy text generation."""
+
+    tokenizer = AutoTokenizer.from_pretrained(save_path)
+    input_ids = tokenizer(TEST_PROMPT, return_tensors="pt")["input_ids"].cuda()
+    print("Inputs:", tokenizer.batch_decode(input_ids))
+
+    model = LlamaForCausalLM.from_pretrained(save_path).cuda().bfloat16()
+    out = model.generate(input_ids, max_new_tokens=100)
+    print("Generation (converted): ", tokenizer.batch_decode(out))
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Convert Nanotron weights to HF format")
+    parser.add_argument("--checkpoint_path", type=Path, default="llama-7b", help="Path to the checkpoint")
+    parser.add_argument("--save_path", type=Path, default="llama-7b-hf", help="Path to save the HF model")
+    parser.add_argument("--tokenizer_name", type=str, default="meta-llama/Llama-2-7b-chat-hf")
+    args = parser.parse_args()
+
+    # Convert Nanotron model to HF format.
+    convert_checkpoint_and_save(
+        checkpoint_path=args.checkpoint_path, save_path=args.save_path, tokenizer_name=args.tokenizer_name
+    )
+
+    # Check if the conversion was successful by generating some text.
+    if args.tokenizer_name is not None:
+        check_converted_model_generation(save_path=args.save_path)

--- a/examples/llama/convert_weights.py
+++ b/examples/llama/convert_weights.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+from typing import Optional
+
+import nanotron
+import torch
+from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.models.llama import LlamaForTraining
+from nanotron.trainer import mark_tied_parameters
+
+
+def get_weight_mapping(config: NanotronLlamaConfig, nt_to_hf: bool = True) -> dict[str, str]:
+    """Returns the nanotron to huggingface parameter mapping if `nt_to_hf`, otherwise the
+    huggingface to nanotron mapping."""
+
+    hf_to_nt_map = {}
+    hf_to_nt_map["lm_head.weight"] = "model.lm_head.pp_block.weight"
+    hf_to_nt_map["model.embed_tokens.weight"] = "model.token_position_embeddings.pp_block.token_embedding.weight"
+    hf_to_nt_map["model.norm.weight"] = "model.final_layer_norm.pp_block.weight"
+    hf_to_nt_map["model.embed_tokens.weight"] = "model.token_position_embeddings.pp_block.token_embedding.weight"
+
+    for i in range(config.num_hidden_layers):
+        hf_prefix = f"model.layers.{i}"
+        nt_prefix = f"model.decoder.{i}.pp_block"
+        hf_to_nt_map[f"{hf_prefix}.self_attn.q_proj.weight"] = f"{nt_prefix}.attn.qkv_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.self_attn.k_proj.weight"] = f"{nt_prefix}.attn.qkv_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.self_attn.v_proj.weight"] = f"{nt_prefix}.attn.qkv_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.self_attn.o_proj.weight"] = f"{nt_prefix}.attn.o_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.mlp.gate_proj.weight"] = f"{nt_prefix}.mlp.gate_up_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.mlp.gate_proj.bias"] = f"{nt_prefix}.mlp.gate_up_proj.bias"
+        hf_to_nt_map[f"{hf_prefix}.mlp.up_proj.weight"] = f"{nt_prefix}.mlp.gate_up_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.mlp.up_proj.bias"] = f"{nt_prefix}.mlp.gate_up_proj.bias"
+        hf_to_nt_map[f"{hf_prefix}.mlp.down_proj.weight"] = f"{nt_prefix}.mlp.down_proj.weight"
+        hf_to_nt_map[f"{hf_prefix}.mlp.down_proj.bias"] = f"{nt_prefix}.mlp.down_proj.bias"
+        hf_to_nt_map[f"{hf_prefix}.input_layernorm.weight"] = f"{nt_prefix}.input_layernorm.weight"
+        hf_to_nt_map[f"{hf_prefix}.post_attention_layernorm.weight"] = f"{nt_prefix}.post_attention_layernorm.weight"
+
+    if nt_to_hf:
+        nt_to_hf_map = {}
+        for hf, nt in hf_to_nt_map.items():
+            # Because the qkv and gate_up projections are separated in the
+            # huggingface format, when we return nanotron to huggingface
+            # we will need to return a list of parameters instead (e.g.
+            # the `qkv_proj` will point to a list `[q_proj, k_proj, v_proj]`).
+            if nt in nt_to_hf_map and isinstance(nt_to_hf_map[nt], list):
+                nt_to_hf_map[nt].append(hf)
+            elif nt in nt_to_hf_map:
+                nt_to_hf_map[nt] = [nt_to_hf_map[nt], hf]
+            else:
+                nt_to_hf_map[nt] = hf
+        return nt_to_hf_map
+    return hf_to_nt_map
+
+
+def get_config_mapping(nt_to_hf: bool = True) -> dict[str, str]:
+    """Returns either the nanotron to huggingface (if `nt_to_hf`)
+    configuration mapping, or the huggingface to nanotron."""
+
+    hf_to_nt_map = {
+        "bos_token_id": "bos_token_id",
+        "eos_token_id": "eos_token_id",
+        "hidden_act": "hidden_act",
+        "hidden_size": "hidden_size",
+        "initializer_range": "initializer_range",
+        "intermediate_size": "intermediate_size",
+        "max_position_embeddings": "max_position_embeddings",
+        "num_attention_heads": "num_attention_heads",
+        "num_hidden_layers": "num_hidden_layers",
+        "num_key_value_heads": "num_key_value_heads",
+        "pad_token_id": "pad_token_id",
+        "pretraining_tp": "pretraining_tp",
+        "rms_norm_eps": "rms_norm_eps",
+        "rope_scaling": "rope_scaling",
+        "tie_word_embeddings": "tie_word_embeddings",
+        "use_cache": "use_cache",
+        "vocab_size": "vocab_size",
+    }
+    if nt_to_hf:
+        return {nt: hf for hf, nt in hf_to_nt_map.items()}
+    return hf_to_nt_map
+
+
+def make_parallel_config(
+    dp: int = 1,
+    pp: int = 1,
+    tp: int = 1,
+):
+    parallel_config = nanotron.config.ParallelismArgs(
+        dp=dp,
+        pp=pp,
+        tp=tp,
+        pp_engine=nanotron.config.AllForwardAllBackwardPipelineEngine(),
+        tp_mode=nanotron.config.TensorParallelLinearMode.ALL_REDUCE,
+        tp_linear_async_communication=False,
+    )
+    return parallel_config
+
+
+def load_nanotron_model(
+    model_config: Optional[NanotronLlamaConfig] = None,
+    device: torch.device = torch.device("cuda"),
+    dtype: torch.dtype = torch.bfloat16,
+    checkpoint_path: Optional[Path] = None,
+) -> LlamaForTraining:
+    """
+    Creates and returns a nanotron model.
+    If `model_config` is None, then `checkpoint_path` must be set, in which case
+    the configuration will be loaded from such path.
+    If `checkpoint_path` is None, then `model_config` must be set, in which case
+    the model created will have random weights.
+    """
+
+    if model_config is None:
+        assert checkpoint_path is not None
+        with open(checkpoint_path / "model_config.json") as f:
+            model_config = NanotronLlamaConfig(**json.load(f))
+    parallel_config = make_parallel_config()
+    parallel_context = nanotron.parallel.ParallelContext(
+        data_parallel_size=parallel_config.dp,
+        pipeline_parallel_size=parallel_config.pp,
+        tensor_parallel_size=parallel_config.tp,
+    )
+    nanotron_model = nanotron.models.build_model(
+        model_builder=lambda: LlamaForTraining(
+            config=model_config,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=dtype,
+        device=device,
+    )
+    mark_tied_parameters(model=nanotron_model, parallel_context=parallel_context)
+    # Load checkpoint directly in memory and then only keep the state dictionary
+    if checkpoint_path is not None:
+        nanotron.serialize.load_weights(
+            model=nanotron_model, parallel_context=parallel_context, root_folder=checkpoint_path
+        )
+    return nanotron_model

--- a/examples/llama/convert_weights.py
+++ b/examples/llama/convert_weights.py
@@ -71,6 +71,7 @@ def get_config_mapping(nt_to_hf: bool = True) -> dict[str, str]:
         "pretraining_tp": "pretraining_tp",
         "rms_norm_eps": "rms_norm_eps",
         "rope_scaling": "rope_scaling",
+        "rope_theta": "rope_theta",
         "tie_word_embeddings": "tie_word_embeddings",
         "use_cache": "use_cache",
         "vocab_size": "vocab_size",

--- a/examples/llama/requirements.txt
+++ b/examples/llama/requirements.txt
@@ -1,0 +1,1 @@
+transformers==4.39.3

--- a/examples/llama/tests/test_conversion.py
+++ b/examples/llama/tests/test_conversion.py
@@ -1,0 +1,251 @@
+# ruff: noqa: E402
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import LlamaForCausalLM
+from utils import set_system_path
+
+set_system_path()
+
+import nanotron
+from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.models.base import init_on_device_and_dtype
+from nanotron.models.llama import LlamaForTraining
+from nanotron.parallel import ParallelContext
+from nanotron.trainer import mark_tied_parameters
+
+from examples.llama.convert_hf_to_nanotron import convert_checkpoint_and_save as convert_hf_to_nt_and_save
+from examples.llama.convert_hf_to_nanotron import convert_hf_to_nt
+from examples.llama.convert_nanotron_to_hf import convert_checkpoint_and_save as convert_nt_to_hf_and_save
+from examples.llama.convert_nanotron_to_hf import convert_nt_to_hf, get_hf_config
+from examples.llama.convert_weights import load_nanotron_model, make_parallel_config
+from tests.helpers.context import TestContext
+from tests.helpers.utils import init_distributed
+
+CONFIG = NanotronLlamaConfig(
+    **{
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "hidden_act": "silu",
+        "hidden_size": 512,
+        "initializer_range": 0.02,
+        "intermediate_size": 1024,
+        "is_llama_config": True,
+        "max_position_embeddings": 128,
+        "num_attention_heads": 8,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 4,
+        "pad_token_id": None,
+        "pretraining_tp": 1,
+        "rms_norm_eps": 1e-06,
+        "rope_scaling": None,
+        "tie_word_embeddings": False,
+        "use_cache": True,
+        "vocab_size": 4096,
+    }
+)
+
+
+BATCH_SIZE = 3
+SEQUENCE_LENGTH = 5
+ATOL = 0.03
+
+
+def create_nanotron_model(parallel_context: ParallelContext) -> LlamaForTraining:
+    parallel_config = make_parallel_config(
+        tp=parallel_context.tensor_parallel_size,
+        dp=parallel_context.data_parallel_size,
+        pp=parallel_context.pipeline_parallel_size,
+    )
+    nanotron_model = nanotron.models.build_model(
+        model_builder=lambda: LlamaForTraining(
+            config=CONFIG,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=torch.bfloat16,
+        device=torch.device("cuda"),
+    )
+    mark_tied_parameters(model=nanotron_model, parallel_context=parallel_context)
+    return nanotron_model
+
+
+def create_huggingface_model() -> LlamaForCausalLM:
+    config_hf = get_hf_config(CONFIG)
+    with init_on_device_and_dtype(torch.device("cuda"), torch.bfloat16):
+        model_hf = LlamaForCausalLM._from_config(config_hf)
+    return model_hf
+
+
+@pytest.fixture(autouse=True, scope="module")
+def fix_seed():
+    torch.manual_seed(0)
+    yield
+
+
+@pytest.fixture
+def input_ids() -> torch.Tensor:
+    return torch.randint(0, CONFIG.vocab_size, size=(BATCH_SIZE, SEQUENCE_LENGTH), device="cuda")
+
+
+def _test_nt_to_hf(parallel_context: ParallelContext, input_ids: torch.Tensor):
+    model_nt = create_nanotron_model(parallel_context)
+    model_hf = create_huggingface_model()
+    convert_nt_to_hf(model_nt, model_hf, CONFIG)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def test_nt_to_hf(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_nt_to_hf)(input_ids=input_ids)
+
+
+def _test_nt_to_hf_with_files(parallel_context: ParallelContext, input_ids: torch.Tensor, test_context: TestContext):
+    # Create and save nanotron model.
+    model_nt = create_nanotron_model(parallel_context)
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path = root / "nanotron"
+    hf_path = root / "hf"
+    nanotron.serialize.save_weights(model=model_nt, parallel_context=parallel_context, root_folder=nt_path)
+    with open(nt_path / "model_config.json", "w+") as f:
+        json.dump(dataclasses.asdict(CONFIG), f)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    del model_nt
+    # Perform conversion.
+    convert_nt_to_hf_and_save(nt_path, hf_path)
+    # Load huggingface and get logits.
+    model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    torch.testing.assert_allclose(logits_nt, logits_hf, atol=ATOL)
+
+
+def test_nt_to_hf_with_files(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_nt_to_hf_with_files)(input_ids=input_ids, test_context=TestContext())
+
+
+def _test_hf_to_nt(parallel_context: ParallelContext, input_ids: torch.Tensor):
+    model_nt = create_nanotron_model(parallel_context)
+    model_hf = create_huggingface_model()
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    torch.testing.assert_allclose(logits_hf, logits_nt, atol=ATOL)  
+
+
+def test_hf_to_nt(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_hf_to_nt)(input_ids=input_ids)
+
+
+def _test_hf_to_nt_with_files(parallel_context: ParallelContext, input_ids: torch.Tensor, test_context: TestContext):
+    # Create and save hf model.
+    model_hf = create_huggingface_model()
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path = root / "nanotron"
+    hf_path = root / "hf"
+    model_hf.save_pretrained(hf_path)
+    logits_hf = model_hf(input_ids).logits
+    del model_hf
+    # Perform conversion.
+    convert_hf_to_nt_and_save(hf_path, nt_path)
+    # Load nanotron and get logits.
+    input_mask = torch.ones_like(input_ids)
+    model_nt = load_nanotron_model(checkpoint_path=nt_path)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL)
+
+
+def test_hf_to_nt_with_files(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_hf_to_nt_with_files)(input_ids=input_ids, test_context=TestContext())
+
+
+def _test_composed_conversion(parallel_context: ParallelContext):
+    # Get HF statedict.
+    model_hf = create_huggingface_model()
+    hf_sd = {key: val.clone() for key, val in model_hf.state_dict().items()}
+    # Convert once to nanotron, save its statedict.
+    model_nt = create_nanotron_model(parallel_context)
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    nt_sd = {key: val.clone() for key, val in model_nt.state_dict().items()}
+    # Convert back to HF, compare statedicts.
+    del model_hf
+    model_hf = create_huggingface_model()
+    convert_nt_to_hf(model_nt, model_hf, CONFIG)
+    hf_sd_new = model_hf.state_dict()
+    assert set(hf_sd_new) == set(hf_sd)
+    assert all(torch.all(hf_sd[key] == hf_sd_new[key]) for key in hf_sd_new)
+    # Convert to nanotron one more time, compare statedicts.
+    del model_nt
+    model_nt = create_nanotron_model(parallel_context)
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    nt_sd_new = model_nt.state_dict()
+    assert set(nt_sd_new) == set(nt_sd)
+    assert all(torch.all(nt_sd[key] == nt_sd_new[key]) for key in nt_sd_new)
+
+
+def test_composed_conversion():
+    init_distributed(tp=1, dp=1, pp=1)(_test_composed_conversion)()
+
+
+def _save_parallel_nanotron(parallel_context: ParallelContext, input_ids: torch.Tensor, nt_path: Path):
+    # Create and save a parallel model.
+    model_nt = create_nanotron_model(parallel_context)
+    nanotron.serialize.save_weights(model=model_nt, parallel_context=parallel_context, root_folder=nt_path)
+    with open(nt_path / "model_config.json", "w+") as f:
+        json.dump(dataclasses.asdict(CONFIG), f)
+
+    # Get parallel predictions.
+    input_ids = input_ids.cuda()  # Move them to the current device index.
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    if torch.distributed.get_rank() == 0:
+        torch.save(logits_nt.detach().cpu(), nt_path / "logits.pt")
+
+    # Convert nanotron to hf, load it and compare logits.
+    # hf_path = root/"hf"
+    # convert_nt_to_hf_and_save(nt_path, hf_path)
+    # model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    # logits_hf = model_hf(input_ids).logits
+
+    # assert logits_nt.size() == logits_hf.size()
+    # assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def _convert_from_parallel(parallel_context: ParallelContext, input_ids: torch.Tensor, nt_path: Path, hf_path: Path):
+    # Convert parallel nanotron to hf, get and save huggingface predictions.
+    convert_nt_to_hf_and_save(nt_path, hf_path)
+    model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    logits_hf = model_hf(input_ids).logits
+    torch.save(logits_hf.detach().cpu(), hf_path / "logits.pt")
+
+
+def test_tensor_parallel_conversion(input_ids: torch.Tensor):
+    # Set up test.
+    test_context = TestContext()
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path = root / "nanotron"
+    hf_path = root / "nanotron"
+
+    # Launch both parts.
+    init_distributed(tp=2, dp=1, pp=1)(_save_parallel_nanotron)(input_ids=input_ids, nt_path=nt_path)
+    assert (nt_path / "logits.pt").exists()
+    init_distributed(tp=1, dp=1, pp=1)(_convert_from_parallel)(input_ids=input_ids, nt_path=nt_path, hf_path=hf_path)
+    assert (hf_path / "logits.pt").exists()
+
+    # Load logits and verify they match.
+    logits_nt = torch.load(nt_path / "logits.pt")
+    logits_hf = torch.load(hf_path / "logits.pt")
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))

--- a/examples/llama/tests/test_conversion.py.orig
+++ b/examples/llama/tests/test_conversion.py.orig
@@ -1,0 +1,264 @@
+# ruff: noqa: E402
+import json
+<<<<<<< HEAD
+from pathlib import Path
+=======
+>>>>>>> main
+
+import pytest
+import torch
+from transformers import LlamaForCausalLM
+from utils import set_system_path
+
+set_system_path()
+
+import nanotron
+from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.models.base import init_on_device_and_dtype
+from nanotron.models.llama import LlamaForTraining
+from nanotron.parallel import ParallelContext
+
+from examples.llama.convert_hf_to_nanotron import convert_checkpoint_and_save as convert_hf_to_nt_and_save
+<<<<<<< HEAD
+from examples.llama.convert_nanotron_to_hf import convert_checkpoint_and_save as convert_nt_to_hf_and_save
+from examples.llama.convert_hf_to_nanotron import convert_hf_to_nt
+from examples.llama.convert_nanotron_to_hf import convert_nt_to_hf, get_hf_config
+from examples.llama.convert_weights import load_nanotron_model
+from tests.helpers.context import TestContext
+from tests.helpers.utils import init_distributed
+=======
+from examples.llama.convert_hf_to_nanotron import convert_hf_to_nt
+from examples.llama.convert_nanotron_to_hf import convert_checkpoint_and_save as convert_nt_to_hf_and_save
+from examples.llama.convert_nanotron_to_hf import convert_nt_to_hf, get_hf_config
+from examples.llama.convert_weights import load_nanotron_model, make_parallel_config
+from tests.helpers.context import TestContext
+from tests.helpers.utils import init_distributed, rerun_if_address_is_in_use
+>>>>>>> main
+
+CONFIG = NanotronLlamaConfig(
+    **{
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "hidden_act": "silu",
+        "hidden_size": 512,
+        "initializer_range": 0.02,
+        "intermediate_size": 1024,
+        "is_llama_config": True,
+        "max_position_embeddings": 128,
+        "num_attention_heads": 8,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 4,
+        "pad_token_id": None,
+        "pretraining_tp": 1,
+        "rms_norm_eps": 1e-06,
+        "rope_scaling": None,
+        "tie_word_embeddings": False,
+        "use_cache": True,
+        "vocab_size": 4096,
+    }
+)
+
+
+BATCH_SIZE = 3
+SEQUENCE_LENGTH = 5
+ATOL = 0.02
+
+
+def create_nanotron_model(pp: int = 1, tp: int = 1, dp: int = 1) -> LlamaForTraining:
+    parallel_config = make_parallel_config(dp, pp, tp)
+    return load_nanotron_model(parallel_config, CONFIG, torch.device("cuda"), torch.bfloat16)
+
+
+def create_huggingface_model() -> LlamaForCausalLM:
+    config_hf = get_hf_config(CONFIG)
+    with init_on_device_and_dtype(torch.device("cuda"), torch.bfloat16):
+        model_hf = LlamaForCausalLM._from_config(config_hf)
+    return model_hf
+
+
+@pytest.fixture(autouse=True, scope="module")
+def fix_seed():
+    torch.manual_seed(0)
+    yield
+
+
+@pytest.fixture
+def input_ids() -> torch.Tensor:
+    return torch.randint(0, CONFIG.vocab_size, size=(BATCH_SIZE, SEQUENCE_LENGTH), device="cuda")
+
+
+def _test_nt_to_hf(parallel_context: ParallelContext, input_ids: torch.Tensor):
+    model_nt = create_nanotron_model()
+    model_hf = create_huggingface_model()
+    convert_nt_to_hf(model_nt, model_hf, CONFIG)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def test_nt_to_hf(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_nt_to_hf)(input_ids=input_ids)
+
+
+def _test_nt_to_hf_with_files(parallel_context: ParallelContext, input_ids: torch.Tensor, test_context: TestContext):
+    # Create and save nanotron model.
+    model_nt = create_nanotron_model()
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path = root / "nanotron"
+    hf_path = root / "hf"
+    nanotron.serialize.save_weights(model=model_nt, parallel_context=parallel_context, root_folder=nt_path)
+    with open(nt_path / "model_config.json", "w+") as f:
+        json.dump(vars(CONFIG), f)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    del model_nt
+    # Perform conversion.
+    convert_nt_to_hf_and_save(nt_path, hf_path)
+    # Load huggingface and get logits.
+    model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def test_nt_to_hf_with_files(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_nt_to_hf_with_files)(input_ids=input_ids, test_context=TestContext())
+
+
+def _test_hf_to_nt(parallel_context: ParallelContext, input_ids: torch.Tensor):
+    model_nt = create_nanotron_model()
+    model_hf = create_huggingface_model()
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def test_hf_to_nt(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_hf_to_nt)(input_ids=input_ids)
+
+
+def _test_hf_to_nt_with_files(parallel_context: ParallelContext, input_ids: torch.Tensor, test_context: TestContext):
+    # Create and save hf model.
+    model_hf = create_huggingface_model()
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path = root / "nanotron"
+    hf_path = root / "hf"
+    model_hf.save_pretrained(hf_path)
+    logits_hf = model_hf(input_ids).logits
+    del model_hf
+    # Perform conversion.
+    convert_hf_to_nt_and_save(hf_path, nt_path)
+    # Load nanotron and get logits.
+    input_mask = torch.ones_like(input_ids)
+    model_nt = load_nanotron_model(checkpoint_path=nt_path)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL)
+
+
+def test_hf_to_nt_with_files(input_ids: torch.Tensor):
+    init_distributed(tp=1, dp=1, pp=1)(_test_hf_to_nt_with_files)(input_ids=input_ids, test_context=TestContext())
+
+
+def _test_composed_conversion(parallel_context: ParallelContext):
+    # Get HF statedict.
+    model_hf = create_huggingface_model()
+    hf_sd = {key: val.clone() for key, val in model_hf.state_dict().items()}
+    # Convert once to nanotron, save its statedict.
+    model_nt = create_nanotron_model()
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    nt_sd = {key: val.clone() for key, val in model_nt.state_dict().items()}
+    # Convert back to HF, compare statedicts.
+    del model_hf
+    model_hf = create_huggingface_model()
+    convert_nt_to_hf(model_nt, model_hf, CONFIG)
+    hf_sd_new = model_hf.state_dict()
+    assert set(hf_sd_new) == set(hf_sd)
+    assert all(torch.all(hf_sd[key] == hf_sd_new[key]) for key in hf_sd_new)
+    # Convert to nanotron one more time, compare statedicts.
+    del model_nt
+    model_nt = create_nanotron_model()
+    convert_hf_to_nt(model_hf, model_nt, CONFIG)
+    nt_sd_new = model_nt.state_dict()
+    assert set(nt_sd_new) == set(nt_sd)
+    assert all(torch.all(nt_sd[key] == nt_sd_new[key]) for key in nt_sd_new)
+
+
+def test_composed_conversion():
+    init_distributed(tp=1, dp=1, pp=1)(_test_composed_conversion)()
+
+
+<<<<<<< HEAD
+def _save_parallel_nanotron(parallel_context: ParallelContext, input_ids: torch.Tensor, nt_path: Path):
+    # Create and save a parallel model.
+    model_nt = create_nanotron_model(tp=parallel_context.tensor_parallel_size, pp=parallel_context.pipeline_parallel_size)
+    # print(torch.distributed.get_rank(), "model_nt", set(p.device for p in model_nt.parameters()))
+    nanotron.serialize.save_weights(model=model_nt, parallel_context=parallel_context, root_folder=nt_path)
+    with open(nt_path/"model_config.json", "w+") as f:
+        json.dump(vars(CONFIG), f)
+
+    # Get parallel predictions.
+    input_ids = input_ids.cuda()  # Move them to the current device index.
+    input_mask = torch.ones_like(input_ids)
+    # print(torch.distributed.get_rank(), "input_ids", input_ids.device)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    if torch.distributed.get_rank() == 0:
+        torch.save(logits_nt.detach().cpu(), nt_path/"logits.pt")
+    # print(torch.distributed.get_rank(), logits_nt.shape)
+
+    # Convert nanotron to hf, load it and compare logits.
+    # hf_path = root/"hf"
+    # convert_nt_to_hf_and_save(nt_path, hf_path)
+    # model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    # logits_hf = model_hf(input_ids).logits
+
+    # assert logits_nt.size() == logits_hf.size()
+    # assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+def _convert_from_parallel(parallel_context: ParallelContext, input_ids: torch.Tensor, nt_path: Path, hf_path: Path):
+    # Convert parallel nanotron to hf, get and save huggingface predictions.
+    convert_nt_to_hf_and_save(nt_path, hf_path)
+    model_hf = LlamaForCausalLM.from_pretrained(hf_path).cuda()
+    logits_hf = model_hf(input_ids).logits
+    torch.save(logits_hf.detach().cpu(), hf_path/"logits.pt")
+
+def test_tensor_parallel_conversion(input_ids: torch.Tensor):
+    # Set up test.
+    test_context = TestContext()
+    root = test_context.get_auto_remove_tmp_dir()
+    nt_path =root/"nanotron"
+    hf_path =root/"nanotron"
+
+    # Launch both parts.
+    init_distributed(tp=2, dp=1, pp=1)(_save_parallel_nanotron)(input_ids=input_ids, nt_path=nt_path)
+    assert (nt_path/"logits.pt").exists()
+    init_distributed(tp=1, dp=1, pp=1)(_convert_from_parallel)(input_ids=input_ids, nt_path=nt_path, hf_path=hf_path)
+    assert (hf_path/"logits.pt").exists()
+
+    # Load logits and verify they match.
+    logits_nt = torch.load(nt_path/"logits.pt")
+    logits_hf = torch.load(hf_path/"logits.pt")
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+=======
+def _test_tensor_parallel_conversion(parallel_context: ParallelContext):
+    model_nt = create_nanotron_model(tp=2)
+    model_hf = create_huggingface_model()
+    convert_nt_to_hf(model_nt, model_hf, CONFIG)
+    input_mask = torch.ones_like(input_ids)
+    logits_nt = model_nt.model(input_ids, input_mask).permute(1, 0, 2)
+    logits_hf = model_hf(input_ids).logits
+    assert logits_nt.size() == logits_hf.size()
+    assert torch.allclose(logits_nt, logits_hf, atol=ATOL), torch.mean(torch.abs(logits_nt - logits_hf))
+
+
+@rerun_if_address_is_in_use()
+def test_tensor_parallel_conversion():
+    init_distributed(tp=2, dp=1, pp=1)(_test_tensor_parallel_conversion)()
+>>>>>>> main

--- a/examples/llama/tests/utils.py
+++ b/examples/llama/tests/utils.py
@@ -1,0 +1,15 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def set_system_path():
+    package = importlib.import_module("nanotron")
+    # NOTE:  Path(package.__file__).parent = .../nanotron/src/nanotron
+    # we want .../nanotron
+    package_path = Path(package.__file__).parent.parent.parent
+    sys.path.insert(0, str(package_path))
+
+    # we also want ../llama
+    llama_path = Path(__file__).parent.parent
+    sys.path.insert(0, str(llama_path))

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -247,7 +247,7 @@ class LRSchedulerArgs:
 
     lr_warmup_steps: number of steps to warmup the learning rate
     lr_warmup_style: linear or constant
-    lr_decay_style: linear or cosine
+    lr_decay_style: linear, cosine or 1-sqrt
     min_decay_lr: minimum learning rate after decay
     lr_decay_steps: optional number of steps to decay the learning rate otherwise will default to train_steps - lr_warmup_steps
     lr_decay_starting_step: optional number of steps to decay the learning rate otherwise will default to train_steps - lr_warmup_steps
@@ -270,9 +270,9 @@ class LRSchedulerArgs:
             self.lr_warmup_style = "linear"
         if self.lr_decay_style is None:
             self.lr_decay_style = "linear"
-        if self.lr_decay_style not in ["linear", "cosine"]:
+        if self.lr_decay_style not in ["linear", "cosine", "1-sqrt"]:
             raise ValueError(
-                f"lr_decay_style should be a string selected in ['linear', 'cosine'] and not {self.lr_decay_style}"
+                f"lr_decay_style should be a string selected in ['linear', 'cosine', '1-sqrt'] and not {self.lr_decay_style}"
             )
         if self.min_decay_lr is None:
             self.min_decay_lr = self.learning_rate

--- a/src/nanotron/config/models_config.py
+++ b/src/nanotron/config/models_config.py
@@ -47,6 +47,7 @@ class LlamaConfig:
     pretraining_tp: int = 1
     rms_norm_eps: float = 1e-6
     rope_scaling: Optional[dict] = None
+    rope_theta: float = 10000.0
     tie_word_embeddings: bool = False
     use_cache: bool = True
     vocab_size: int = 32000

--- a/src/nanotron/helpers.py
+++ b/src/nanotron/helpers.py
@@ -146,6 +146,12 @@ def lr_scheduler_builder(optimizer: Optimizer, lr_scheduler_args: LRSchedulerArg
                     * (lr_decay_steps - (current_step - lr_decay_starting_step))
                     / lr_decay_steps
                 )
+            elif lr_scheduler_args.lr_decay_style == "1-sqrt":
+                lmbda = (
+                    lr_scheduler_args.min_decay_lr
+                    + (initial_lr - lr_scheduler_args.min_decay_lr)
+                    * (1 - math.sqrt((current_step - lr_decay_starting_step) / lr_decay_steps))
+                )
             else:
                 raise ValueError(f"Unknown decay style {lr_scheduler_args.lr_decay_style}")
 

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -320,10 +320,11 @@ class CausalSelfAttention(nn.Module, AttachableStore):
         self.rotary_embedding = RotaryEmbedding(
             dim=self.d_qk,
             end=config.max_position_embeddings,
+            theta=config.rope_theta,
         )
 
         # NOTE: Only supported for training (TODO(fmom): position_ids not supported yet)
-        self.flash_rotary_embedding = FlashRotaryEmbedding(dim=self.d_qk, interleaved=True)
+        self.flash_rotary_embedding = FlashRotaryEmbedding(dim=self.d_qk, base=config.rope_theta, interleaved=True)
 
         self.o_proj = TensorParallelRowLinear(
             config.num_attention_heads * self.d_qk,

--- a/tests/nanoset/test_build_nanoset_dataloader.py
+++ b/tests/nanoset/test_build_nanoset_dataloader.py
@@ -1,4 +1,9 @@
+import sys
 from math import isclose
+from pathlib import Path
+
+package_path = Path(__file__).parent.parent
+sys.path.append(str(package_path))
 
 import numpy as np
 import pytest


### PR DESCRIPTION
As discussed in #46, the implementation of row parallel linear backward pass seems wrong, _when TP mode is reduce-scatter and async communication is enabled_. To be more specific, the gradient of input tensor is produced by 
1. compute local slice of input gradient
2. allgather slice of input gradient

This will produce the same input gradient for all TP shards, which is not the correct behavior of Row Parallel Linear layer.
Also, the check of input gradient for row parallel is also missing in test cases. After adding the test, the result for `test_tensor_parallel.py::test_row_linear[True-TensorParallelLinearMode.REDUCE_SCATTER-4-1-1]` is as follows:
![Snipaste_2024-05-16_18-37-08](https://github.com/huggingface/nanotron/assets/10362198/47b22180-6b67-4eb2-a20c-4c9702cc9f59)
Only 1/4 of the input gradient values are correct, because that's the locally computed part.

This PR does the following:
1. Fixed the backward pass of `_RowLinearAsyncCommunication`, in a similar way to forward pass of `_ColumnLinearAsyncCommunication` that overlaps communication with part of computation.
2. Add the missing test that checks the correctness of input gradient in `_RowLinearAsyncCommunication`

This bug is related to convergence and can be triggered when TP mode is reduce-scatter, and async communication is enabled (which is a common setup for users). 

Please fix this, thanks!
