### PR TITLE
add rope_theta config var for llama

### DIFF
--- a/src/nanotron/config/models_config.py
+++ b/src/nanotron/config/models_config.py
@@ -47,6 +47,7 @@ class LlamaConfig:
     pretraining_tp: int = 1
     rms_norm_eps: float = 1e-6
     rope_scaling: Optional[dict] = None
+    rope_theta: float = 10000.0
     tie_word_embeddings: bool = False
     use_cache: bool = True
     vocab_size: int = 32000

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -320,10 +320,11 @@ class CausalSelfAttention(nn.Module, AttachableStore):
         self.rotary_embedding = RotaryEmbedding(
             dim=self.d_qk,
             end=config.max_position_embeddings,
+            theta=config.rope_theta,
         )
 
         # NOTE: Only supported for training (TODO(fmom): position_ids not supported yet)
-        self.flash_rotary_embedding = FlashRotaryEmbedding(dim=self.d_qk, interleaved=True)
+        self.flash_rotary_embedding = FlashRotaryEmbedding(dim=self.d_qk, base=config.rope_theta, interleaved=True)
 
         self.o_proj = TensorParallelRowLinear(
             config.num_attention_heads * self.d_qk,


### PR DESCRIPTION
This allows changing RoPE's theta hyperparameter for Llama models. For example, Llama 3 uses `theta = 500000` instead of the default `10000`.