### PR TITLE
Fix overflow in nanosets with big datasets

### DIFF
--- a/src/nanotron/data/nanoset.py
+++ b/src/nanotron/data/nanoset.py
@@ -91,9 +91,9 @@ class Nanoset(torch.utils.data.Dataset):
         self.dataset_buffer = memoryview(self.dataset_buffer_mmap)
 
         # uint16 -> 2 bytes per token, int32 -> 4 bytes per token
-        offset = dataset_sample * self.sequence_length * (np.iinfo(self.token_dtype).bits / 8)
+        offset = int(dataset_sample) * self.sequence_length * int(np.iinfo(self.token_dtype).bits / 8)
         input_ids_tokens = np.frombuffer(
-            self.dataset_buffer, dtype=self.token_dtype, count=(self.sequence_length + 1), offset=int(offset)
+            self.dataset_buffer, dtype=self.token_dtype, count=(self.sequence_length + 1), offset=offset
         )
 
         # Return tokens as np.int32 as Torch can't handle uint16


### PR DESCRIPTION
When a nanoset is particularly big (>4 GB), the calculation of `offset` (the actual location within the memmap) can overflow. The issue is with the line

`offset = dataset_sample * self.sequence_length * (np.iinfo(self.token_dtype).bits / 8)`

Here, `dataset_sample` is a numpy `"uint"`, and the calculation of `offset` can overflow since numpy's `"uint"` type is 32 bits. The solution is to promote everything to native Python `int` first, which has automatic overflow.