### PR TITLE
Adding support for training chat models

### DIFF
--- a/examples/chat_config.yaml
+++ b/examples/chat_config.yaml
@@ -1,0 +1,97 @@
+checkpoints:
+  checkpoint_interval: 1000
+  checkpoints_path: /mloscratch/homes/solergib/converter/nanotron/checkpoints
+  checkpoints_path_is_shared_file_system: false
+  resume_checkpoint_path: null
+  save_initial_state: false
+data_stages:
+- data:
+    dataset:
+      hf_dataset: Open-Orca/SlimOrca
+      hf_dataset_split: train
+      conversation_column_name: conversations
+      train_on_completions_only: true
+      remove_cross_attention: true
+    num_loading_workers: 1
+    seed: 42
+  name: General purpose training (Single dataset)
+  start_training_step: 1
+general:
+  benchmark_csv_path: null
+  consumed_train_samples: null
+  ignore_sanity_checks: true
+  project: Chat
+  run: Llama3-8B
+  seed: 42
+  step: null
+lighteval: null
+logging:
+  iteration_step_info_interval: 1
+  log_level: info
+  log_level_replica: info
+model:
+  ddp_bucket_cap_mb: 25
+  dtype: bfloat16
+  init_method:
+    std: 0.025
+  make_vocab_size_divisible_by: 1
+  model_config:
+    bos_token_id: 128000
+    eos_token_id: 128001
+    hidden_act: silu
+    hidden_size: 4096
+    initializer_range: 0.02
+    intermediate_size: 14336
+    is_llama_config: true
+    max_position_embeddings: 8192
+    num_attention_heads: 32
+    num_hidden_layers: 4
+    num_key_value_heads: 8
+    pad_token_id: null
+    pretraining_tp: 1
+    rms_norm_eps: 1.0e-05
+    rope_scaling: null
+    rope_theta: 500000.0
+    tie_word_embeddings: false
+    use_cache: true
+    vocab_size: 128256
+optimizer:
+  accumulate_grad_in_fp32: true
+  clip_grad: 1.0
+  learning_rate_scheduler:
+    learning_rate: 0.0003
+    lr_decay_starting_step: null
+    lr_decay_steps: 98
+    lr_decay_style: cosine
+    lr_warmup_steps: 2
+    lr_warmup_style: linear
+    min_decay_lr: 1.0e-05
+  optimizer_factory:
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    name: adamW
+    torch_adam_is_fused: true
+  weight_decay: 0.01
+  zero_stage: 0
+parallelism:
+  dp: 1
+  expert_parallel_size: 1
+  pp: 1
+  pp_engine: 1f1b
+  tp: 1
+  tp_linear_async_communication: false
+  tp_mode: ALL_REDUCE
+profiler: null
+tokenizer:
+  tokenizer_max_length: null
+  tokenizer_name_or_path: meta-llama/Meta-Llama-3-8B-Instruct
+  tokenizer_revision: null
+tokens:
+  batch_accumulation_per_replica: 1
+  limit_test_batches: 0
+  limit_val_batches: 0
+  micro_batch_size: 1
+  sequence_length: 8192
+  train_steps: 100
+  val_check_interval: -1

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -108,10 +108,26 @@ class NanosetDatasetsArgs:
 
 
 @dataclass
+class ChatDatasetsArgs:
+    hf_dataset: str
+    hf_dataset_split: str
+    conversation_column_name: str
+    # Debug
+    train_on_completions_only: bool = True
+    remove_cross_attention: bool = True
+
+    def __post_init__(self):
+        if self.hf_dataset_split is None:
+            self.hf_dataset_split = "train"
+        if self.conversation_column_name is None:
+            self.conversation_column_name = "conversations"
+
+
+@dataclass
 class DataArgs:
     """Arguments related to the data and data files processing"""
 
-    dataset: Union[PretrainDatasetsArgs, NanosetDatasetsArgs]
+    dataset: Union[PretrainDatasetsArgs, NanosetDatasetsArgs, ChatDatasetsArgs]
     seed: Optional[int]
     num_loading_workers: Optional[int] = 1
 

--- a/src/nanotron/data/chat_dataset.py
+++ b/src/nanotron/data/chat_dataset.py
@@ -1,0 +1,141 @@
+from typing import List
+
+import numpy as np
+from datasets import load_dataset
+from datasets.distributed import split_dataset_by_node
+from nanotron.data.chat_tokenizer import ChatTokenizer
+from nanotron.data.utils import (
+    build_labels,
+    build_labels_completions_only,
+    build_position_ids,
+    build_position_ids_dummy,
+)
+from torch.utils.data import IterableDataset
+from transformers import AutoTokenizer
+
+
+class ChatDataset(IterableDataset):
+    """
+    Chat Dataset for training models with:
+        1. Packing
+        2. No cross-contamination between packed samples
+        3. Train on completitions only
+
+    Args:
+        dataset_path (str): Path to the dataset in the file system. If provided, data will be loaded from this path instead of downloaded.
+        tokenizer_name_or_path (str): Path to a directory containing vocabulary files required by the tokenizer or the model id of a predefined tokenizer hosted inside a model repo on the Hugging Face Hub.
+        seq_len (int): max sequence length
+        train_on_completions_only (bool): Whether to just train on completitions or not. To be deleted
+        remove_cross_attention (bool): Whether to just attend to the tokens from the same sample or to all (Vanilla mechanism). To be deleted
+        split (str): Split of the dataset to train on
+        conversation_column_name (str): Column name of the dataset containing the conversations
+        dp_rank (int): rank of the current data parallel process
+        dp_ranks_size (int): number of data parallel processes participating in training
+    """
+
+    def __init__(
+        self,
+        dataset_path: str,
+        tokenizer_name_or_path,
+        sequence_length: int,
+        conversation_column_name: str,
+        train_on_completions_only: bool = True,
+        remove_cross_attention: bool = True,
+        split: str = "train",
+        dp_rank: int = 0,
+        dp_ranks_size: int = 1,
+        skip_num_samples: int = None,  # TODO Delete, check later comment
+        seed: int = 1234,
+    ) -> None:
+
+        # TODO: Support checkpointing for resuming training. We have to store the number of consumed samples from the dataset (Which is different from the number of steps) and the buffers.
+        #       skip_num_samples will fail, as it's computed with the number of steps and as we are packing sequences we might have consumed MORE samples from the dataset
+        # TODO: Support interleaving datasets
+
+        self.dataset_path = dataset_path
+        self.chat_tokenizer = ChatTokenizer(tokenizer_name_or_path)
+        self.sequence_length = sequence_length
+        self.conversation_column_name = conversation_column_name
+        self.skip_num_samples = skip_num_samples
+        self.seed = seed
+
+        # Load, split and shuffle dataset. Also skip samples if resuming training.
+        self.dataset = load_dataset(dataset_path, split=split, streaming=True)
+        self.dataset = split_dataset_by_node(self.dataset, dp_rank, dp_ranks_size)
+        self.dataset = self.dataset.shuffle(seed=seed, buffer_size=10_000)
+
+        # TODO delete, just 4 switching the training only on completitions setting
+        if train_on_completions_only:
+            self.create_labels = build_labels_completions_only
+        else:
+            self.create_labels = build_labels
+
+        # TODO delete, just 4 switching the remove cross-attention setting
+        if remove_cross_attention:
+            self.create_position_ids = build_position_ids
+        else:
+            self.create_position_ids = build_position_ids_dummy
+
+        # Todo delete (debug), just change the dict keys
+        self.debug_tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_name_or_path, token="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"
+        )  # TODO delete debug
+        self.debug_tokenizer.chat_template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['from'] + '<|end_header_id|>\n\n'+ message['value'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>' }}{% endif %}"
+
+    def __iter__(self):
+        max_buffer_token_len = 1 + self.sequence_length
+        buffer_tokens: List[int] = []
+        buffer_is_completition: List[int] = []
+        buffer_lengths: List[int] = []
+
+        while True:
+            for sample in iter(self.dataset):
+                tokens, is_completition = self.chat_tokenizer(sample[self.conversation_column_name])
+
+                # TODO assert that tokenized conversations are not longer than max_buffer_token_len?
+
+                # TODO delete (debug). The [:-1] of tokens is because apply chat template doesn't adds eos (NOT eot) token
+                assert (
+                    self.debug_tokenizer.apply_chat_template(sample["conversations"]) == tokens[:-1]
+                ), f'{self.debug_tokenizer.apply_chat_template(sample["conversations"])}\n\n{tokens[:-1]}'
+
+                buffer_tokens.extend(tokens)
+                buffer_is_completition.extend(is_completition)
+                buffer_lengths.append(len(tokens))
+
+                if len(buffer_tokens) > max_buffer_token_len:  # Can't pack more samples, yield
+                    # Pop last sample from buffers
+                    sample_tokens = buffer_tokens[: -len(tokens)]
+                    sample_completitions = buffer_is_completition[: -len(tokens)]
+                    sample_lengths = buffer_lengths[:-1]
+
+                    # TODO delete (debug)
+                    assert len(sample_tokens) == len(sample_completitions) == sum(sample_lengths)
+
+                    # Reset tokens buffers
+                    buffer_tokens = tokens.copy()
+                    buffer_is_completition = is_completition.copy()
+                    buffer_lengths = [len(tokens)]
+
+                    # Pad to max_buffer_token_len. Pad token added in ChatTokenizer init if necessary
+                    sample_tokens.extend(
+                        [self.chat_tokenizer.tokenizer.pad_token_id] * (max_buffer_token_len - len(sample_tokens))
+                    )
+                    sample_completitions.extend([False] * (max_buffer_token_len - len(sample_completitions)))
+
+                    # TODO delete, just 4 switching the training only on completitions setting
+                    labels = self.create_labels(sample_tokens, sample_completitions)
+
+                    # TODO delete, jjust 4 switching the remove cross-attention setting
+                    position_ids = self.create_position_ids(sample_lengths, self.sequence_length)
+
+                    # TODO delete (debug)
+                    assert len(sample_tokens) == max_buffer_token_len
+
+                    yield {
+                        "input_ids": np.array(sample_tokens[:-1], dtype=np.int32),
+                        "label_ids": labels,
+                        "position_ids": position_ids,
+                    }
+
+            print("Consumed all samples, dataset is being re-looped.")

--- a/src/nanotron/data/chat_dataset.py
+++ b/src/nanotron/data/chat_dataset.py
@@ -124,7 +124,7 @@ class ChatDataset(IterableDataset):
                     # TODO delete, just 4 switching the training only on completitions setting
                     labels = self.create_labels(sample_tokens, sample_completitions)
 
-                    # TODO delete, jjust 4 switching the remove cross-attention setting
+                    # TODO delete, just 4 switching the remove cross-attention setting
                     position_ids = self.create_position_ids(sample_lengths, self.sequence_length)
 
                     # TODO delete (debug)

--- a/src/nanotron/data/chat_dataset.py
+++ b/src/nanotron/data/chat_dataset.py
@@ -77,9 +77,7 @@ class ChatDataset(IterableDataset):
             self.create_position_ids = build_position_ids_dummy
 
         # Todo delete (debug), just change the dict keys
-        self.debug_tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_name_or_path, token="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"
-        )  # TODO delete debug
+        self.debug_tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)  # TODO delete debug
         self.debug_tokenizer.chat_template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['from'] + '<|end_header_id|>\n\n'+ message['value'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>' }}{% endif %}"
 
     def __iter__(self):

--- a/src/nanotron/data/chat_tokenizer.py
+++ b/src/nanotron/data/chat_tokenizer.py
@@ -1,0 +1,81 @@
+from typing import List, Tuple
+
+from transformers import AutoTokenizer
+
+
+class ChatTokenizer:
+    """
+    The ChatTokenizer encodes a conversation applying the Llama3 Chat Template and returns the role (Either User or Assistant) of each token
+
+    Args:
+        tokenizer_name_or_path (str): A path to a directory containing vocabulary files required by the tokenizer or the model id of a predefined tokenizer hosted inside a model repo on the Hugging Face Hub.
+    """
+
+    def __init__(self, tokenizer_name_or_path: str):
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
+
+        # Add pad token if necessary
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.add_special_tokens({"pad_token": "<|eot_id|>"})
+
+    def __call__(self, conversation: List[dict]) -> Tuple[List[int], List[bool]]:
+        """
+        Applies the Llama3 chat template, encodes the conversation and returns the tokens along with a bool value for each token whether if the token belongs to the answer of the assistant or not to be able to just train on the assistant answers
+        Args:
+            conversation (List[dict]):  List of dicts where each dict contains the "from" key to specify the emisor del mensaje and the "value" key with the message.
+                                        Same format as SlimOrca dataset with possible from values: "System", "human" and "gpt"
+        Example:
+            conversation: [ { "from": "system", "value": "You are an AI assistant that follows instruction extremely well. Help as much as you can."},
+                          { "from": "human", "value": "Answer the following question: - number is 54 - debutteam is pittsburgh steelers - draftpick is 166 - birth date is 24 may 1982 - weight is 243 - nfl is wal475737 - debutyear is 2005 - finalteam is new york sentinels - statlabel is tackles sacks interceptions - heightin is 3 - statvalue is 9 0.0 1 - heightft is 6 - college is temple - birth place is pottstown , pennsylvania - draftyear is 2005 - position is linebacker - draftround is 5 - finalyear is 2009 Given the details above, guess who could this information be about.\nAnswer:"},
+                          { "from": "gpt", "value": "The information provided seems to refer to Rian Wallace, a former NFL player."} ]
+
+            After applying chat template:
+                <|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+                You are an AI assistant that follows instruction extremely well. Help as much as you can.<|eot_id|><|start_header_id|>human<|end_header_id|>
+
+                Answer the following question: - number is 54 - debutteam is pittsburgh steelers - draftpick is 166 - birth date is 24 may 1982 - weight is 243 - nfl is wal475737 - debutyear is 2005 - finalteam is new york sentinels - statlabel is tackles sacks interceptions - heightin is 3 - statvalue is 9 0.0 1 - heightft is 6 - college is temple - birth place is pottstown , pennsylvania - draftyear is 2005 - position is linebacker - draftround is 5 - finalyear is 2009 Given the details above, guess who could this information be about.
+                Answer:<|eot_id|><|start_header_id|>gpt<|end_header_id|>
+
+                The information provided seems to refer to Rian Wallace, a former NFL player.<|eot_id|>
+          returns:
+              tokens (List[int]): A list of tokens e.g. [128000, 128006,   9125, 128007,    271,   2675,    527, ...,  12873,   2851,     13, 128009, 128001]
+              is_completitions (List[bool]): A list of bools whether the tokens belong to the assistant answer or not e.g. [False, False, False, ..., False,  True,  True,  True,  True]
+        """
+        tokens = []
+        # Append <|begin_of_text|>
+        tokens.append(self.tokenizer.bos_token_id)
+        is_completitions = [False] * len(tokens)
+
+        for message in conversation:
+            message_tokens, message_completitions = self.encode_message(message)
+            tokens.extend(message_tokens)
+            is_completitions.extend(message_completitions)
+
+        # Append <|end_of_text|> token
+        tokens.extend(self.tokenizer.encode("<|end_of_text|>", add_special_tokens=False))
+        is_completitions.append(True)
+
+        return tokens, is_completitions
+
+    def encode_message(self, message: dict) -> Tuple[List[int], List[int]]:
+        # TODO The "from", "value", "gpt" keys are form SlimOrcar Dataset. Llama3 uses another ones. We should stick to a
+        # single format and document it properly rather than supporting multiple formats, as each one will need a different
+        # ChatTokenizer and the idea is that all Datasets share the same ChatTokenizer
+
+        # Encode header
+        tokens = self.tokenizer.encode(
+            f"<|start_header_id|>{message['from']}<|end_header_id|>\n\n", add_special_tokens=False
+        )
+        is_completitions = [False] * len(tokens)
+
+        # Encode message
+        tokens.extend(self.tokenizer.encode(message["value"].strip(), add_special_tokens=False))
+
+        # Append <|eot_id|> token
+        tokens.append(self.tokenizer.eos_token_id)
+
+        # True if token belongs to assistant answer, False otherwise
+        is_completitions.extend([True if message["from"] == "gpt" else False] * (len(tokens) - len(is_completitions)))
+
+        return tokens, is_completitions

--- a/src/nanotron/data/utils.py
+++ b/src/nanotron/data/utils.py
@@ -33,11 +33,11 @@ def count_dataset_indexes(dataset_idx: np.ndarray, n_datasets: int):
     return counts
 
 
-# TODO Find a more elegant way
+# TODO Find a more elegant way. e.g. extend instead of append. OK, so no extend
 # We could compute position ids after tokenizing each sample but we will still miss the last length of the padding tokens
 def build_position_ids(lengths, sequence_length) -> np.array:
-    lengths.append((sequence_length - sum(lengths)))  # Append length of the padding tokens
     position_ids = [list(range(length)) for length in lengths]  # Create position ids list
+    position_ids.append([0] * (sequence_length - sum(lengths)))  # Append position_ids of the padding tokens
     return np.array([x for xs in position_ids for x in xs], dtype=np.int32)  # Flatten list of position ids
 
 

--- a/src/nanotron/data/utils.py
+++ b/src/nanotron/data/utils.py
@@ -1,6 +1,11 @@
-from typing import List
+from dataclasses import dataclass
+from typing import Dict, List, Union
 
 import numpy as np
+import torch
+from nanotron import distributed as dist
+from nanotron.parallel import ParallelContext
+from nanotron.parallel.pipeline_parallel.tensor_pointer import TensorPointer
 
 
 def normalize(weights: List[float]) -> List[np.array]:
@@ -26,3 +31,89 @@ def count_dataset_indexes(dataset_idx: np.ndarray, n_datasets: int):
         counts.append(np.count_nonzero(dataset_idx == dataset))
 
     return counts
+
+
+# TODO Find a more elegant way
+# We could compute position ids after tokenizing each sample but we will still miss the last length of the padding tokens
+def build_position_ids(lengths, sequence_length) -> np.array:
+    lengths.append((sequence_length - sum(lengths)))  # Append length of the padding tokens
+    position_ids = [list(range(length)) for length in lengths]  # Create position ids list
+    return np.array([x for xs in position_ids for x in xs], dtype=np.int32)  # Flatten list of position ids
+
+
+# TODO delete, just 4 switching the remove cross-attention setting
+def build_position_ids_dummy(lengths, sequence_length) -> np.array:
+    return np.array(list(range(sequence_length)), dtype=np.int32)  # TODO numpy arange
+
+
+# TODO delete, just 4 switching the training only on completitions setting. This will be in the __iter__ method instead of a function
+def build_labels_completions_only(input_ids, is_completitions):
+    labels = np.where(
+        is_completitions, input_ids, -100
+    )  # Mask tokens that don't belong to the completitions by the Assistant
+    return np.array(labels[1:], dtype=np.int32)
+
+
+# TODO delete, just 4 switching the training only on completitions setting
+def build_labels(input_ids, is_completitions):
+    return np.array(input_ids[1:], dtype=np.int32)
+
+
+@dataclass
+class DataCollatorForChatDataset:  # TODO Find a better name
+    """
+    Data collator used with Chat Dataset.
+
+    - sequence_length: Sequence length of each sample in the batch
+    - input_pp_rank: Discards last input id token
+    - output_pp_rank: Discards first label id token
+    - other pp ranks: Don't have data. Instead, we use `TensorPointer` to point to the rank having the data.
+    """
+
+    sequence_length: int
+    input_pp_rank: int
+    output_pp_rank: int
+    parallel_context: ParallelContext
+
+    def __call__(self, examples: List[Dict[str, List[int]]]) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
+        # Process the case when current rank doesn't require data. We return `TensorPointer` that points to ranks having the data.
+
+        current_pp_rank = dist.get_rank(self.parallel_context.pp_pg)
+        if current_pp_rank not in [
+            self.input_pp_rank,
+            self.output_pp_rank,
+        ]:
+            assert all(len(example) == 0 for example in examples)
+            return {
+                "input_ids": TensorPointer(group_rank=self.input_pp_rank),
+                "input_mask": TensorPointer(group_rank=self.input_pp_rank),
+                "label_ids": TensorPointer(group_rank=self.output_pp_rank),
+                "label_mask": TensorPointer(group_rank=self.output_pp_rank),
+            }
+
+        # TODO clean this, as we are flatting the batch there is no necessity for vstack but we need the batch dimension too
+        input_ids = np.vstack([examples[i]["input_ids"] for i in range(len(examples))])  # (b, s)
+        label_ids = np.vstack([examples[i]["label_ids"] for i in range(len(examples))])  # (b, s)
+        position_ids = np.vstack([examples[i]["position_ids"] for i in range(len(examples))])  # (b, s)
+
+        result: Dict[str, Union[np.ndarray, TensorPointer]] = {}
+
+        result["input_ids"] = TensorPointer(group_rank=self.input_pp_rank)
+        result["input_mask"] = TensorPointer(group_rank=self.input_pp_rank)
+        result["label_ids"] = TensorPointer(group_rank=self.output_pp_rank)
+        result["label_mask"] = TensorPointer(group_rank=self.output_pp_rank)
+
+        # Process inputs
+        if current_pp_rank == self.input_pp_rank:
+            result["input_ids"] = input_ids
+            result["input_mask"] = np.ones((1, self.sequence_length), dtype=np.bool_)
+            result["position_ids"] = position_ids
+
+        # Process labels: shift them to the left
+        if current_pp_rank == self.output_pp_rank:
+            result["label_ids"] = label_ids
+            result["label_mask"] = np.ones((1, self.sequence_length), dtype=np.bool_)
+
+        # Cast np.array to torch.Tensor
+        result = {k: v if isinstance(v, TensorPointer) else torch.from_numpy(v) for k, v in result.items()}
+        return result

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """PyTorch LLaMa model."""
 
-from typing import Dict, Optional, Union, List
+from typing import Dict, Optional, Union
 
 import torch
 from torch import nn
@@ -884,6 +884,7 @@ class LlamaForTraining(NanotronModel):
         self,
         input_ids: Union[torch.Tensor, TensorPointer],
         input_mask: Union[torch.Tensor, TensorPointer],
+        position_ids: Union[torch.Tensor, TensorPointer],
         label_ids: Union[torch.Tensor, TensorPointer],
         label_mask: Union[torch.Tensor, TensorPointer],
     ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:


### PR DESCRIPTION
> [!CAUTION]
> 🚨 This is a draft, still in development, and further testing needs to be done. Feel free to leave any comments!

This PR includes everything necessary to train chat models with:
1. Sample packing
2. No cross-attention contamination between packed samples
3. Training on completions only (the answers generated by the model)

This image from @sz128 is very useful to understand 1. & 2.:
![image](https://github.com/huggingface/nanotron/assets/74564958/9185c244-56d1-4d14-b958-f4fd7c8adb1d)

I am developing this feature with `axolotl`'s implementation as a reference. The current status is as follows:
## Dataset
### IterableDatasets
This time, I have opted for and [IterableDataset](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/data/chat_dataset.py#L17) instead of a map style one. The obvious benefits are that we tokenize on the fly, which allows us to easily experiment with different models/tokenizers/chat templates and saves disk space by not storing the tokens. However, the drawbacks are:
- The division between the different DP groups is done with the `split_dataset_by_node` function, which will divide the dataset's `n_shards` among the number of DP groups. If not evenly divisible, each DP group keeps 1 sample of the dataset, skipping the other examples. This is obviously not very optimal. Also, remember that since we tokenize the data on the fly, even if we divide by `n_shards`, each DP group will produce a different amount of tokens. Thus, after X steps, one DP group will have consumed its dataset 1.5 times, while another with longer samples will have done so 0.8 times.
- Since each sample of the dataset produces a different number of tokens, it is impossible to predict how many samples from the dataset we will need to construct each batch of the dataloader. This, along with building the batches with a buffer that processes samples from the dataset until it has enough tokens, complicates the task of recovering the state of the dataloader when resuming training. For now, there is NO way to recover the state, but it is possible to achieve this using solutions like [StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader) that checkpoint the state of the DataLoader and Dataset. In our case, we would only need to checkpoint the number of samples we have extracted from the Dataset + the token buffers, this for each DP group.
- The most concerning issue today is that to recover the state, we have to use the `.skip()` method. This method is not optimal as it consumes all the samples from the Dataset, but it seems they are [working on a better solution](https://github.com/huggingface/datasets/issues/5380). This is a problem if you have to skip many samples from a XXXL dataset.
- It is very complicated (not impossible) to work with `num_workers > 1`, as the dataset would need to be divided at the worker level, and then it would not be trivial to recover the state if this value changes.

Of all these inconveniences, the one that worries me the most is the third one, but I trust that they will develop an optimal solution soon. We can easily develop solutions for the first and second issues, and the fourth one does not seem too problematic, although we could also address it.
### How Samples Are Produced
[In short](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/data/chat_dataset.py#L83), we extract samples from the dataset and apply the chat template until we can no longer fit a full Question-Answer pair into the sequence length of the sample we are constructing. We save this last Question-Answer pair for the next sample and pad the sample we are constructing (In the case of the Llama3 tokenizer as we don't have a pad token we use the <|eot_id|> token). We do this so that each sample has several completed Question-Answer pairs. This packing is greedy, although there are more complex strategies to minimize the number of pad tokens.

The important thing here is that we have developed the [`ChatTokenizer`](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/data/chat_tokenizer.py#L6) class to apply the chat template manually and not use solutions like the `apply_chat_template` method of tokenizers. We do this to know at the token level if each one belongs to the assistant's responses or not for the feature of training only on the assistant's tokens. I have added an assert to verify that the result of applying the chat template is exactly the same as the `apply_chat_template` method of tokenizers.
### Dataset Samples
I have developed [this notebook](https://colab.research.google.com/drive/1jrDIc52crI9od9u4Z4s90mEUz5nsuF8g?usp=sharing) so you can check the batches produced by the DataLoader. In summary, the most relevant features are:
> [!NOTE] 
> The `label id` token '-' is actually -100. We switch it because `tokenizer.convert_ids_to_tokens` can't convert '-100' token.
- When training just on the assistant's answers, the first token we predict is **ĊĊ**, which corresponds to "\n\n" from the Llama3 chat template. When interacting with a model we prompt a question + apply chat template and the model starts generating from this "\n\n" token.
<img width="532" alt="Screenshot 2024-05-28 at 02 21 50" src="https://github.com/huggingface/nanotron/assets/74564958/0fa4fa9d-7cfc-4d0c-b0f2-db77ed2c47c3">

- Every Question-Answer pair has its own `position_ids`. This will be relevant later for specifying FA2 to not attend to other samples.
<img width="571" alt="Screenshot 2024-05-28 at 02 22 09" src="https://github.com/huggingface/nanotron/assets/74564958/e581f456-10eb-4469-b3e2-42cdef305815">

### Other Considerations
- We flatten the MBS to reduce the padding tokens.
- For now, we only support the Open-Orca/SlimOrca dataset format. Check the Keys & Values of the dicts.
- The Open-Orca/SlimOrca is a single turn conversation dataset, so we are appending the <|end_of_text|> token after each assistant's message.
## Collator
The [collator](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/data/utils.py#L63) is very similar to `DataCollatorForCLM`, except we now add the `position_ids`. I have also removed several assertions.
## DataLoader
The [DataLoader](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/data/dataloader_builder.py#L68) is pretty simple. As I mentioned, it is not trivial to work with `num_workers`.
## Config
I have added a new configuration called [`ChatDatasetsArgs`](https://github.com/TJ-Solergibert/nanotron/blob/36b1c1814bf71a5fe31f95472001ee0c2ae05ad6/src/nanotron/config/config.py#L111) which includes:
- `hf_dataset`: The name or path of the dataset we will stream.
- `hf_dataset_split` ("train"): The split of the dataset.
- `conversation_column_name`: The name of the column from which to extract the conversations.
For debugging purposes, deleted in the final release:
- `train_on_completions_only`: Whether to just train on completions or not.
- `remove_cross_attention`: Whether to just attend to the tokens from the same sample or to all (Vanilla mechanism).

As I already mentioned, the final two configurations will be for evaluating the effect of these two functionalities. I would remove them for the final release since I do not see the benefit of not activating them.

### What Is Still Missing:
- I still need to implement everything related to FA2 and the mechanism to eliminate cross-attention contamination. The most relevant part which belongs to point 2 (No cross-attention contamination between packed samples) can be found [here](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/src/axolotl/monkeypatch/llama_attn_hijack_flash.py). I hope to finish it this week and present results with comparisons starting next week.

### TODOs:
- Checkpoint DataLoader states to resume training (StatefulDataLoader).
- Support interleaving datasets.
- Improve helper functions.
- Add tests
- Clarify chat dataset format (Dictionary keys)