### PR TITLE
add rope_theta to hf conversion script

### DIFF
--- a/examples/llama/convert_weights.py
+++ b/examples/llama/convert_weights.py
@@ -71,6 +71,7 @@ def get_config_mapping(nt_to_hf: bool = True) -> dict[str, str]:
         "pretraining_tp": "pretraining_tp",
         "rms_norm_eps": "rms_norm_eps",
         "rope_scaling": "rope_scaling",
+        "rope_theta": "rope_theta",
         "tie_word_embeddings": "tie_word_embeddings",
         "use_cache": "use_cache",
         "vocab_size": "vocab_size",


### PR DESCRIPTION
`rope_theta` was missing from the hf -> nt mapping in the llama conversion script