### PR TITLE
Fix: Update wrong typing on the function get_local_ranks

### DIFF
--- a/src/nanotron/parallel/context.py
+++ b/src/nanotron/parallel/context.py
@@ -125,7 +125,7 @@ class ParallelContext:
         device_id = local_rank
         torch.cuda.set_device(torch.cuda.device(device_id))
 
-    def get_local_ranks(self, world_rank: int) -> Tuple[int, int, int]:
+    def get_local_ranks(self, world_rank: int) -> Tuple[int, int, int, int]:
         return tuple(i.item() for i in np.where(self.world_rank_matrix == world_rank))
 
     def destroy(self):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -20,7 +20,7 @@ def _test_init_parallel_context(parallel_context: ParallelContext):
 
     world_rank = dist.get_rank(parallel_context.world_pg)
     ranks3d = parallel_context.get_local_ranks(world_rank)
-    assert isinstance(ranks3d, tuple) and len(ranks3d)
+    assert isinstance(ranks3d, tuple) and len(ranks3d) == 4
 
     assert isinstance(parallel_context.world_rank_matrix, np.ndarray)
     assert isinstance(parallel_context.world_ranks_to_pg, dict)


### PR DESCRIPTION
## What does this PR do?
- Fixing the return type of the function `get_local_ranks`
- Update the associated test to ensure, it does not get out-of-sync with the underlying code anymore

## Why?
`np.where(self.world_rank_matrix == world_rank)` returns a single "data point" of the following matrix:
```python
ranks = np.arange(0, world_size).reshape(
            (
                self.expert_parallel_size,
                self.pipeline_parallel_size,
                self.data_parallel_size,
                self.tensor_parallel_size,
            )
        )
self.world_rank_matrix: np.ndarray = ranks
```
Which is a 4d matrix, so the "data point" is a 4d tuple of `np.array` of 1 element.
