### PR TITLE
Add layer-wise activation recomputation to llama model

### DIFF
--- a/src/nanotron/config/parallelism_config.py
+++ b/src/nanotron/config/parallelism_config.py
@@ -23,6 +23,7 @@ class ParallelismArgs:
         pp_engine: Pipeline engine to use between "1f1b" and "afab"
         tp_mode: TP mode to use between "all_reduce" and "reduce_scatter": all_reduce is normal, reduce_scatter activate sequence parallelism
         tp_linear_async_communication: Whether to use async communication in TP linear layers
+        recompute_layer: Whether to recompute each Transformer layer to save memory.
     """
 
     dp: int
@@ -31,6 +32,7 @@ class ParallelismArgs:
     pp_engine: Optional[PipelineEngine] = None
     tp_mode: Optional[TensorParallelLinearMode] = None
     tp_linear_async_communication: Optional[bool] = None
+    recompute_layer: bool = False
 
     expert_parallel_size: int = 1
 

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -645,7 +645,7 @@ class LlamaDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         sequence_mask: torch.Tensor,
         ) -> List[torch.Tensor]:
-        return CheckpointFunction.apply(self._core_forward, hidden_states, sequence_mask)
+        return CheckpointFunction.apply(self._core_forward, True, hidden_states, sequence_mask)
 
     def forward(
         self,
@@ -653,7 +653,7 @@ class LlamaDecoderLayer(nn.Module):
         sequence_mask: Union[torch.Tensor, TensorPointer],
     ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
         
-        if self.recompute_layer:
+        if self.recompute_layer and not isinstance(hidden_states, TensorPointer):
             hidden_states, sequence_mask = self._checkpointed_forward(hidden_states, sequence_mask)
         else:
             hidden_states, sequence_mask = self._core_forward(hidden_states, sequence_mask)

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional, Union, List
 
 import torch
 from torch import nn
+from torch.utils.checkpoint import CheckpointFunction
 
 from nanotron import distributed as dist
 from nanotron import logging
@@ -617,12 +618,14 @@ class LlamaDecoderLayer(nn.Module):
 
         self.post_attention_layernorm = TritonRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.mlp = MLP(config=config, parallel_config=parallel_config, tp_pg=tp_pg)
-
-    def forward(
+        
+        self.recompute_layer = parallel_config.recompute_layer
+        
+    def _core_forward(
         self,
         hidden_states: Union[torch.Tensor, TensorPointer],
         sequence_mask: Union[torch.Tensor, TensorPointer],
-    ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
+    ) -> List[Union[torch.Tensor, TensorPointer]]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
@@ -635,11 +638,30 @@ class LlamaDecoderLayer(nn.Module):
         hidden_states = self.mlp(hidden_states=hidden_states)["hidden_states"]
         hidden_states = hidden_states + residual
 
+        return hidden_states, output["sequence_mask"]
+        
+    def _checkpointed_forward(
+        self,
+        hidden_states: torch.Tensor,
+        sequence_mask: torch.Tensor,
+        ) -> List[torch.Tensor]:
+        return CheckpointFunction.apply(self._core_forward, hidden_states, sequence_mask)
+
+    def forward(
+        self,
+        hidden_states: Union[torch.Tensor, TensorPointer],
+        sequence_mask: Union[torch.Tensor, TensorPointer],
+    ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
+        
+        if self.recompute_layer:
+            hidden_states, sequence_mask = self._checkpointed_forward(hidden_states, sequence_mask)
+        else:
+            hidden_states, sequence_mask = self._core_forward(hidden_states, sequence_mask)
+
         return {
             "hidden_states": hidden_states,
-            "sequence_mask": output["sequence_mask"],
+            "sequence_mask": sequence_mask,
         }
-
 
 class Embedding(nn.Module, AttachableStore):
     def __init__(self, tp_pg: dist.ProcessGroup, config: LlamaConfig, parallel_config: Optional[ParallelismArgs]):


### PR DESCRIPTION
When benchmarking Nanotron with big models (e.g. Llama2-70b) we found that Nanotron consumes more memory than Megatron under the same parallel configuration. Besides the fix https://github.com/huggingface/nanotron/pull/203, we also add layer-wise activation recomputation (also known as gradient checkpointing) to mitigate this issue. Currently it is controlled by flag `recompute_layer` in `src/nanotron/config/parallelism_config.py`. 

Megatron also offers more fine-grained control over activation recomputation, but I found it is not straightforward to apply that to Nanotron mainly because of the pipelineblock abstraction. It would be nice if developers could shed some light on this. And I would be glad to help formalize this PR.