### PR TITLE
change naonset args definition to make it compatible with the parser

### DIFF
--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -93,18 +93,13 @@ class PretrainDatasetsArgs:
 
 @dataclass
 class NanosetDatasetsArgs:
-    dataset_folder: Union[str, dict, List[str]]
+    dataset_folder: Union[str, List[str]]
+    dataset_weights: Optional[List[float]] = None
 
     def __post_init__(self):
         if isinstance(self.dataset_folder, str):  # Case 1: 1 Dataset folder
             self.dataset_folder = [self.dataset_folder]
             self.dataset_weights = [1]
-        elif isinstance(self.dataset_folder, List):  # Case 2: > 1 Dataset folder
-            self.dataset_weights = None  # Set to None so we consume all the samples randomly
-        elif isinstance(self.dataset_folder, dict):  # Case 3: dict with > 1 dataset_folder and weights
-            tmp_dataset_folder = self.dataset_folder.copy()
-            self.dataset_folder = list(tmp_dataset_folder.keys())
-            self.dataset_weights = list(tmp_dataset_folder.values())
 
 
 @dataclass


### PR DESCRIPTION
should now be 
```
dataset=NanosetDatasetsArgs(
    dataset_folder=[
        "datasets/cosmopedia-v2",
        "datasets/fineweb-edu-dedup",
    ],
    dataset_weights = [70, 30],
),
```
Instead of 
```
dataset=NanosetDatasetsArgs(
    dataset_folder={
        "datasets/cosmopedia-v2":70,
        "datasets/fineweb-edu-dedup":30,
    },
),
```
Otherwise the it doesn't load/save the right config 