### PR TITLE
Fix loading scheduler when having more than one param_group

### DIFF
--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -236,6 +236,7 @@ def load(
     load_optimizer(optimizer=optimizer, parallel_context=parallel_context, root_folder=root_folder)
     load_lr_scheduler(
         lr_scheduler=lr_scheduler,
+        parallel_context=parallel_context,
         root_folder=root_folder,
     )
     return checkpoint_metadata

--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -236,7 +236,7 @@ def load(
     load_optimizer(optimizer=optimizer, parallel_context=parallel_context, root_folder=root_folder)
     load_lr_scheduler(
         lr_scheduler=lr_scheduler,
-        is_zero=not optimizer.inherit_from(optim.ZeroDistributedOptimizer),
+        is_zero=optimizer.inherit_from(optim.ZeroDistributedOptimizer),
         parallel_context=parallel_context,
         root_folder=root_folder,
     )

--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -203,7 +203,7 @@ def save(
     dist.barrier(parallel_context.world_pg)
 
 
-ckpt_path(config: Config, parallel_context: ParallelContext) -> Optional[Path]:
+def parse_ckpt_path(config: Config, parallel_context: ParallelContext) -> Optional[Path]:
     """Parse checkpoint path from config and download checkpoint from S3 if needed.
 
     Args:

--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -236,6 +236,7 @@ def load(
     load_optimizer(optimizer=optimizer, parallel_context=parallel_context, root_folder=root_folder)
     load_lr_scheduler(
         lr_scheduler=lr_scheduler,
+        is_zero=not optimizer.inherit_from(optim.ZeroDistributedOptimizer),
         parallel_context=parallel_context,
         root_folder=root_folder,
     )

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -206,6 +206,7 @@ class DistributedTrainer:
         if self.init_checkpoint_path is not None:
             load_lr_scheduler(
                 lr_scheduler=self.lr_scheduler,
+                is_zero=self.config.optimizer.zero_stage,
                 parallel_context=self.parallel_context,
                 root_folder=self.init_checkpoint_path,
             )
@@ -864,11 +865,7 @@ class DistributedTrainer:
                 dist.get_rank(self.parallel_context.dp_pg) == 0
             ),  # We only save the weights on DP==0
             should_save_optimizer=True,
-            should_save_lr_scheduler=bool(
-                dist.get_rank(self.parallel_context.dp_pg) == 0
-                and dist.get_rank(self.parallel_context.tp_pg) == 0
-                and dist.get_rank(self.parallel_context.expert_pg) == 0
-            ),  # We only save the lr_scheduler on DP==0 && TP==0 && EP==0
+            should_save_lr_scheduler=True,
             should_save_config=bool(
                 dist.get_rank(self.parallel_context.world_pg) == 0
             ),  # We only save the config on world_rank==0

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -865,8 +865,10 @@ class DistributedTrainer:
             ),  # We only save the weights on DP==0
             should_save_optimizer=True,
             should_save_lr_scheduler=bool(
-                dist.get_rank(self.parallel_context.dp_pg) == 0 and dist.get_rank(self.parallel_context.tp_pg)
-            ),  # We only save the lr_scheduler on DP==0 && TP==0
+                dist.get_rank(self.parallel_context.dp_pg) == 0
+                and dist.get_rank(self.parallel_context.tp_pg) == 0
+                and dist.get_rank(self.parallel_context.expert_pg) == 0
+            ),  # We only save the lr_scheduler on DP==0 && TP==0 && EP==0
             should_save_config=bool(
                 dist.get_rank(self.parallel_context.world_pg) == 0
             ),  # We only save the config on world_rank==0


### PR DESCRIPTION
Solves #221 

When training with PP every PP rank gets a different set & quantity of layers, so we need to store the `lr_scheduler` state dict of each PP rank to be able to resume training properly.  (Check size of state dicts)

<img width="566" alt="image" src="https://github.com/user-attachments/assets/56441d2b-e406-48b6-9673-b9695f03bae4">

Similar to how optimizer states and model parameters are stored, we just save the LR scheduler in the DP=TP=EP=0 ranks.

PD: The photo is from a first fix where accidentally stored a statedict for each TP rank (Useless)