### PR TITLE
Load random states from checkpoint

### DIFF
--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -87,6 +87,7 @@ from nanotron.scaling.parametrization import ParametrizationMethod
 from nanotron.serialize import (
     load_lr_scheduler,
     load_meta,
+    load_random_states,
     load_weights,
     parse_ckpt_path,
     save,
@@ -170,6 +171,11 @@ class DistributedTrainer:
         self.random_states = init_random_states(
             parallel_config=self.config.parallelism, tp_pg=self.parallel_context.tp_pg
         )
+        if self.init_checkpoint_path is not None:
+            self.random_states = load_random_states(
+                parallel_context=self.parallel_context,
+                root_folder=self.init_checkpoint_path,
+            )
         self.model = self.init_model()  # Defines self.model
         self.unwrapped_model: NanotronModel = (
             self.model.module if isinstance(self.model, DistributedDataParallel) else self.model


### PR DESCRIPTION
Model's random states are saved into checkpoint but not loaded during recovery which cause non-deterministic behavior.