### PR TITLE
Fix initial_lr when resuming training

### DIFF
--- a/src/nanotron/helpers.py
+++ b/src/nanotron/helpers.py
@@ -165,7 +165,7 @@ def lr_scheduler_builder(optimizer: Optimizer, lr_scheduler_args: LRSchedulerArg
     # NOTE: get learning rate scheduler for each param group
     lr_lambdas = []
     for param_group in optimizer.get_base_optimizer().param_groups:
-        lr_lambdas.append(get_lr_lambda_for_param_group(lr=param_group["initial_lr"]))
+        lr_lambdas.append(get_lr_lambda_for_param_group(lr=lr_scheduler_args.learning_rate))
 
     assert len(lr_lambdas) == len(
         optimizer.get_base_optimizer().param_groups

--- a/src/nanotron/helpers.py
+++ b/src/nanotron/helpers.py
@@ -165,7 +165,7 @@ def lr_scheduler_builder(optimizer: Optimizer, lr_scheduler_args: LRSchedulerArg
     # NOTE: get learning rate scheduler for each param group
     lr_lambdas = []
     for param_group in optimizer.get_base_optimizer().param_groups:
-        lr_lambdas.append(get_lr_lambda_for_param_group(lr=param_group["lr"]))
+        lr_lambdas.append(get_lr_lambda_for_param_group(lr=param_group["initial_lr"]))
 
     assert len(lr_lambdas) == len(
         optimizer.get_base_optimizer().param_groups


### PR DESCRIPTION
The argument initial_lr in lambda_lr() is initialized incorrectly from the **learning rate** of an optimizer's parameter groups. This causes the learning rate to be set incorrectly when models are resumed from checkpoints trained with standard parametrization LR schedulers.

It should instead be initialized from the **initial learning rate** of the optimizer's param groups.

See this issue comment for context: https://github.com/huggingface/nanotron/issues/233#issuecomment-2481663592