### PR TITLE
Small fixes when resuming training

### DIFF
--- a/src/nanotron/sanity_checks.py
+++ b/src/nanotron/sanity_checks.py
@@ -232,10 +232,6 @@ def before_optim_step_sanity_checks(
                 msg=lambda err: f"[Before optimizer step] Tied weights {name} are not synchronized. {err}",
             )
 
-        # SANITY CHECK: optimizer's lr is synchronized with lr_scheduler
-        for group in unwrapped_model.optimizer.param_groups:
-            assert group["lr"] == unwrapped_model.lr_scheduler.get_last_lr()[0]
-
         # SANITY CHECK: run model specific sanity checks
         unwrapped_model.before_optim_step_sanity_checks()
 

--- a/src/nanotron/serialize/optimizer.py
+++ b/src/nanotron/serialize/optimizer.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Tuple
@@ -148,6 +149,9 @@ def load_optimizer(
     if int(ckp_tp_size) != int(parallel_context.tp_pg.size()) or int(ckp_pp_size) != int(
         parallel_context.pp_pg.size()
     ):
+        warnings.warn(
+            "You are resuming in a different PP size, so optimizer states need to be checked. Feel free to open a PR if you work on this!"
+        )
         assert (
             param_shard_metadata is not None
         ), f"You have to pass how the original parameters are sharded in order to resume in a different tensor parallel size, ckp_tp_size: {ckp_tp_size}, current tp_size: {parallel_context.tp_pg.size()}"

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -470,7 +470,9 @@ class DistributedTrainer:
     def training_step(
         self, dataloader: Iterator[Dict[str, Union[torch.Tensor, TensorPointer]]]
     ) -> Tuple[Iterable[Dict], Optional[torch.Tensor]]:
-        before_tbi_sanity_checks(self.config, self.parallel_context, self.unwrapped_model, self.grad_accumulator)
+        before_tbi_sanity_checks(
+            self.config, self.parallel_context, self.unwrapped_model, self.grad_accumulator, self.lr_scheduler
+        )
 
         if self.iteration_step < 5:
             log_memory(logger=logger)

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -195,7 +195,7 @@ class DistributedTrainer:
                 parallel_context=self.parallel_context,
                 root_folder=self.init_checkpoint_path,
                 param_shard_metadata=self.param_shard_metadata,
-                model=self.model,
+                model=self.unwrapped_model,
             )
 
         # Init learning rate scheduler


### PR DESCRIPTION
- adapted config to be able to resume training with nanotron
- made sure optimizer states reshard correctly when going from TP=1 to TP>1
- fixed optimizer states dtype when loading from checkpoint (load directly in fp32 instead of loading in bf16 then recasting to fp32)
- fix small bug where LR is set to initial_lr only in 1st step instead of resuming from last lr (never trust pytorch too much)
- small fix in case of resuming training with DP>1 and TP>1
- fix loading non sharded optim states