### PR TITLE
Add shuffling in Nanotron for subsequent epochs when data is repeated

### DIFF
--- a/src/nanotron/data/nanoset.py
+++ b/src/nanotron/data/nanoset.py
@@ -111,14 +111,26 @@ class Nanoset(torch.utils.data.Dataset):
         dataset_index, dataset_sample_index = build_nanoset_index_helper(
             n_samples=samples_per_epoch, weights=self.dataset_weights, dataset_sizes=self.dataset_lengths
         )
-        # Shuffle the indexes the same way
-        numpy_random_state = np.random.RandomState(self.random_seed)
-        numpy_random_state.shuffle(dataset_index)
-        numpy_random_state = np.random.RandomState(self.random_seed)
-        numpy_random_state.shuffle(dataset_sample_index)
-        # Concatenate num_epochs the shuffled indexes
-        dataset_index = np.concatenate([dataset_index for _ in range(num_epochs)])
-        dataset_sample_index = np.concatenate([dataset_sample_index for _ in range(num_epochs)])
+
+        # Shuffle indices in each epoch with different random seeds and concatenate them
+        r = np.random.RandomState(self.random_seed)
+        epoch_random_seeds = r.randint(0, 2**32 - 1, num_epochs)
+        dataset_indices = []
+        dataset_sample_indices = []
+        for i in range(num_epochs):
+            # Shuffle the sample and dataset indices in epoch with a given seed
+            numpy_random_state = np.random.RandomState(epoch_random_seeds[i])
+            numpy_random_state.shuffle(dataset_index)
+            numpy_random_state = np.random.RandomState(epoch_random_seeds[i])
+            numpy_random_state.shuffle(dataset_sample_index)
+
+            dataset_indices.append(dataset_index)
+            dataset_sample_indices.append(dataset_sample_index)
+
+        # Concatenate the within-epoch shuffled indices
+        dataset_index = np.concatenate(dataset_indices)
+        dataset_sample_index = np.concatenate(dataset_sample_indices)
+
         # Just keep the necessary samples
         dataset_index = dataset_index[: self.train_split_num_samples]
         dataset_sample_index = dataset_sample_index[: self.train_split_num_samples]


### PR DESCRIPTION
Nanoset's index builder does not re-shuffle dataset and sample indices within epochs when training secondary, third, etc epochs. It instead concatenates a copy of the same indices for any repeated data. This PR adds unique within-epoch shuffling for each epoch.

See the following issue: https://github.com/huggingface/nanotron/issues/237 

I ran the tests in `tests/nanotron`:

```
=========================================================================== warnings summary ===========================================================================
tests/helpers/context.py:7: 35 warnings
  /home/faton/projects/text/nanotron_dev/nanotron/tests/helpers/context.py:7: PytestCollectionWarning: cannot collect test class 'TestContext' because it has a __init__ constructor (from: nanoset/test_build_nanoset_dataloader.py)
    class TestContext:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 12 passed, 35 warnings in 44.55s ===================================================================
```