### PR TITLE
[NEW] Llama3.2 weight converters 🦙

### DIFF
--- a/examples/config_llama3.2-3B.yaml
+++ b/examples/config_llama3.2-3B.yaml
@@ -1,0 +1,100 @@
+checkpoints:
+  checkpoint_interval: 20
+  checkpoints_path: checkpoints/nanotron_training/Nanotron-Llama-3.2-3B-FT
+  checkpoints_path_is_shared_file_system: false
+  resume_checkpoint_path: checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B
+  save_initial_state: false
+  load_lr_scheduler: false
+  load_optimizer: false
+data_stages:
+- data:
+    dataset:
+      dataset_folder: /store/swissai/a06/datasets_tokenized/nanotron/Meta-Llama-3-8B/fineweb-edu-sample-100BT
+    num_loading_workers: 1
+    seed: 42
+  name: General purpose training (Single dataset)
+  start_training_step: 1
+general:
+  benchmark_csv_path: null
+  consumed_train_samples: null
+  ignore_sanity_checks: true
+  project: Llama3.2
+  run: llama
+  seed: 42
+  step: null
+lighteval: null
+logging:
+  iteration_step_info_interval: 1
+  log_level: info
+  log_level_replica: info
+model:
+  ddp_bucket_cap_mb: 25
+  dtype: bfloat16
+  init_method:
+    std: 0.025
+  make_vocab_size_divisible_by: 128
+  model_config:
+    bos_token_id: 128000
+    eos_token_id: 128001
+    hidden_act: silu
+    hidden_size: 3072
+    initializer_range: 0.02
+    intermediate_size: 8192
+    is_llama_config: true
+    max_position_embeddings: 8192
+    num_attention_heads: 24
+    num_hidden_layers: 28
+    num_key_value_heads: 8
+    pad_token_id: null
+    pretraining_tp: 1
+    rms_norm_eps: 1.0e-05
+    rope_scaling: 
+      factor: 32.0
+      high_freq_factor: 4.0
+      low_freq_factor: 1.0
+      original_max_position_embeddings: 8192
+      rope_type: llama3
+    rope_theta: 500000.0
+    tie_word_embeddings: true
+    use_cache: true
+    vocab_size: 128256
+optimizer:
+  accumulate_grad_in_fp32: true
+  clip_grad: 1.0
+  learning_rate_scheduler:
+    learning_rate: 0.0003
+    lr_decay_starting_step: null
+    lr_decay_steps: 98
+    lr_decay_style: cosine
+    lr_warmup_steps: 2
+    lr_warmup_style: linear
+    min_decay_lr: 1.0e-05
+  optimizer_factory:
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    name: adamW
+    torch_adam_is_fused: true
+  weight_decay: 0.01
+  zero_stage: 0
+parallelism:
+  dp: 2
+  expert_parallel_size: 1
+  pp: 1
+  pp_engine: 1f1b
+  tp: 2
+  tp_linear_async_communication: false
+  tp_mode: ALL_REDUCE
+profiler: null
+tokenizer:
+  tokenizer_max_length: null
+  tokenizer_name_or_path: meta-llama/Llama-3.2-3B
+  tokenizer_revision: null
+tokens:
+  batch_accumulation_per_replica: 4
+  limit_test_batches: 0
+  limit_val_batches: 0
+  micro_batch_size: 2
+  sequence_length: 8192
+  train_steps: 200
+  val_check_interval: -1

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -160,6 +160,8 @@ class CheckpointsArgs:
     save_final_state: Optional[bool] = False
     resume_checkpoint_path: Optional[xPath] = None
     checkpoints_path_is_shared_file_system: Optional[bool] = False
+    load_lr_scheduler: Optional[bool] = True
+    load_optimizer: Optional[bool] = True
 
     def __post_init__(self):
         if isinstance(self.checkpoints_path, str):

--- a/src/nanotron/config/models_config.py
+++ b/src/nanotron/config/models_config.py
@@ -50,7 +50,7 @@ class LlamaConfig:
     rope_theta: float = 10000.0
     rope_interleaved: bool = (
         False  # The default value has been True, but for loading Llama3 checkpoints you have to set it to False
-    )
+    ) # TODO(tj.solergibert) Depreciate this arg
     tie_word_embeddings: bool = False
     use_cache: bool = True
     vocab_size: int = 32000

--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -105,6 +105,7 @@ def save(
 
             save_lr_scheduler(
                 lr_scheduler=lr_scheduler,
+                is_zero=config.optimizer.zero_stage,
                 parallel_context=parallel_context,
                 root_folder=root_folder,
             )

--- a/tools/converters/convert_hf_to_nanotron.py
+++ b/tools/converters/convert_hf_to_nanotron.py
@@ -1,0 +1,257 @@
+"""
+torchrun --nproc-per-node 1 tools/converters/convert_hf_to_nanotron.py --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B --pretrained-model-name-or-path meta-llama/Llama-3.2-3B
+"""
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+import yaml
+from nanotron import logging
+from nanotron.config import Config, GeneralArgs, LoggingArgs, ModelArgs, ParallelismArgs, TokenizerArgs
+from nanotron.config.models_config import ExistingCheckpointInit
+from nanotron.config.models_config import LlamaConfig as LlamaConfigNanotron
+from nanotron.logging import log_rank, set_ranks_logging_level
+from nanotron.models import build_model
+from nanotron.models.llama import LlamaForTraining
+from nanotron.parallel import ParallelContext
+from nanotron.parallel.parameters import sanity_check
+from nanotron.serialize import TrainingMetadata, save_meta, save_weights
+from nanotron.serialize.metadata import DataStageMetadata
+from nanotron.trainer import mark_tied_parameters
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+logger = logging.get_logger(__name__)
+
+DEVICE = torch.device("cpu")
+TORCH_DTYPE = torch.bfloat16
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="Nanotron Model")
+    group.add_argument(
+        "--nanotron-checkpoint-path",
+        type=str,
+        required=True,
+        help="A path to a directory to store the converted Nanotron Checkpoint",
+    )
+
+    group = parser.add_argument_group(title="HuggingFace Model")
+    group.add_argument(
+        "--pretrained-model-name-or-path",
+        type=str,
+        required=True,
+        help="A path to a directory containing model weights saved using save_pretrained() or the model id of a pretrained model hosted inside a model repo on the Hugging Face Hub",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+    # Init Nanotron Parallel Utilities
+    parallel_config = ParallelismArgs(dp=1, pp=1, tp=1)
+
+    parallel_context = ParallelContext(
+        data_parallel_size=parallel_config.dp,
+        pipeline_parallel_size=parallel_config.pp,
+        tensor_parallel_size=parallel_config.tp,
+    )
+
+    set_ranks_logging_level(parallel_context=parallel_context, logging_config=LoggingArgs())
+
+    # Load Llama3-8B HF model
+    log_rank(
+        f"Loading pretrained Llama3 Model: {args.pretrained_model_name_or_path}",
+        logger=logger,
+        level=logging.INFO,
+        rank=0,
+    )
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        args.pretrained_model_name_or_path, torch_dtype=TORCH_DTYPE, attn_implementation="flash_attention_2"
+    ).to(DEVICE)
+    hf_config = hf_model.config
+
+    # Set Nanotron LlamaConfig
+    nanotron_llama_config = LlamaConfigNanotron(
+        bos_token_id=hf_config.bos_token_id,
+        eos_token_id=hf_config.eos_token_id,
+        hidden_act=hf_config.hidden_act,
+        hidden_size=hf_config.hidden_size,
+        initializer_range=hf_config.initializer_range,
+        intermediate_size=hf_config.intermediate_size,
+        is_llama_config=True,
+        max_position_embeddings=hf_config.max_position_embeddings,
+        num_attention_heads=hf_config.num_attention_heads,
+        num_hidden_layers=hf_config.num_hidden_layers,
+        num_key_value_heads=hf_config.num_key_value_heads,
+        pad_token_id=None,
+        pretraining_tp=hf_config.pretraining_tp,
+        rms_norm_eps=hf_config.rms_norm_eps,
+        rope_scaling=hf_config.rope_scaling,
+        rope_theta=hf_config.rope_theta,
+        tie_word_embeddings=hf_config.tie_word_embeddings,
+        use_cache=hf_config.use_cache,
+        vocab_size=hf_config.vocab_size,
+    )
+
+    # Init Llama3-8B Nanotron model
+    log_rank("Init empty Nanotron Llama3 Model", logger=logger, level=logging.INFO, rank=0)
+    nanotron_model = build_model(
+        model_builder=lambda: LlamaForTraining(
+            config=nanotron_llama_config,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=TORCH_DTYPE,
+        device=DEVICE,
+    )
+
+    mark_tied_parameters(model=nanotron_model, parallel_context=parallel_context)
+    sanity_check(root_module=nanotron_model)
+
+    # Copy params from HF to Nanotron
+    log_rank("Copying weights from HF model to Nanotron model...", logger=logger, level=logging.INFO, rank=0)
+    with torch.no_grad():
+        # Token embeddings
+        log_rank("Copying Token Embeddings...", logger=logger, level=logging.INFO, rank=0)
+        assert (
+            nanotron_model.model.token_position_embeddings.pp_block.token_embedding.weight.shape
+            == hf_model.model.embed_tokens.weight.shape
+        )
+        nanotron_model.model.token_position_embeddings.pp_block.token_embedding.weight.copy_(
+            hf_model.model.embed_tokens.weight
+        )
+
+        # Decoder layers
+        for i in tqdm(
+            range(nanotron_llama_config.num_hidden_layers),
+            desc="Copying Hidden Layers",
+            total=nanotron_llama_config.num_hidden_layers,
+        ):
+            # Input layer norm
+            assert (
+                hf_model.model.layers[i].input_layernorm.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.input_layernorm.weight.shape
+            )
+            nanotron_model.model.decoder[i].pp_block.input_layernorm.weight.copy_(
+                hf_model.model.layers[i].input_layernorm.weight
+            )
+
+            # Self attn
+            ## QKV
+            tmp_qkv_proj = torch.cat(
+                [
+                    hf_model.model.layers[i].self_attn.q_proj.weight,
+                    hf_model.model.layers[i].self_attn.k_proj.weight,
+                    hf_model.model.layers[i].self_attn.v_proj.weight,
+                ],
+                dim=0,
+            )
+            assert tmp_qkv_proj.shape == nanotron_model.model.decoder[i].pp_block.attn.qkv_proj.weight.shape
+            nanotron_model.model.decoder[i].pp_block.attn.qkv_proj.weight.copy_(tmp_qkv_proj)
+
+            ## O
+            assert (
+                hf_model.model.layers[i].self_attn.o_proj.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.attn.o_proj.weight.shape
+            )
+            nanotron_model.model.decoder[i].pp_block.attn.o_proj.weight.copy_(
+                hf_model.model.layers[i].self_attn.o_proj.weight
+            )
+
+            # MLP
+            ## Gate Up Proj
+            tmp_gate_up_proj = torch.cat(
+                [
+                    hf_model.model.layers[i].mlp.gate_proj.weight,
+                    hf_model.model.layers[i].mlp.up_proj.weight,
+                ],
+                dim=0,
+            )
+
+            assert tmp_gate_up_proj.shape == nanotron_model.model.decoder[i].pp_block.mlp.gate_up_proj.weight.shape
+            nanotron_model.model.decoder[i].pp_block.mlp.gate_up_proj.weight.copy_(tmp_gate_up_proj)
+
+            ## Down Proj
+            assert (
+                hf_model.model.layers[i].mlp.down_proj.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.mlp.down_proj.weight.shape
+            )
+            nanotron_model.model.decoder[i].pp_block.mlp.down_proj.weight.copy_(
+                hf_model.model.layers[i].mlp.down_proj.weight
+            )
+
+            # Post attn layer norm
+            assert (
+                hf_model.model.layers[i].post_attention_layernorm.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.post_attention_layernorm.weight.shape
+            )
+            nanotron_model.model.decoder[i].pp_block.post_attention_layernorm.weight.copy_(
+                hf_model.model.layers[i].post_attention_layernorm.weight
+            )
+
+        # Last layer norm
+        log_rank("Copying Final Layer Norm...", logger=logger, level=logging.INFO, rank=0)
+        assert nanotron_model.model.final_layer_norm.pp_block.weight.shape == hf_model.model.norm.weight.shape
+        nanotron_model.model.final_layer_norm.pp_block.weight.copy_(hf_model.model.norm.weight)
+
+        # LM_Head
+        log_rank("Copying LM Head...", logger=logger, level=logging.INFO, rank=0)
+        assert nanotron_model.model.lm_head.pp_block.weight.shape == hf_model.lm_head.weight.shape
+        nanotron_model.model.lm_head.pp_block.weight.copy_(hf_model.lm_head.weight)
+
+    log_rank("Copied weights from HF model to Nanotron model!", logger=logger, level=logging.INFO, rank=0)
+    # Store weights
+    nanotron_checkpoint_path = Path(args.nanotron_checkpoint_path)
+    save_weights(model=nanotron_model, parallel_context=parallel_context, root_folder=nanotron_checkpoint_path)
+
+    # Store metadata
+    log_rank("Storing Nanotron model Configs and Metadata!", logger=logger, level=logging.INFO, rank=0)
+    training_metadata = TrainingMetadata(
+        last_train_step=0,
+        consumed_train_samples=0,
+        data_stages=[DataStageMetadata(name="Empty", consumed_train_samples=0, start_training_step=0)],
+    )
+    save_meta(
+        root_folder=nanotron_checkpoint_path, parallel_context=parallel_context, training_metadata=training_metadata
+    )
+    # Store Tokenizer into Nanotron Checkpoint folder
+    tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model_name_or_path)
+    tokenizer.save_pretrained(nanotron_checkpoint_path)
+
+    # Store Config and Model Config files
+    with open(nanotron_checkpoint_path / "config.yaml", "w") as f:
+        config = Config(
+            general=GeneralArgs(project="Nanotron", run="Llama3"),
+            parallelism=parallel_config,
+            model=ModelArgs(
+                init_method=ExistingCheckpointInit(nanotron_checkpoint_path),
+                model_config=nanotron_llama_config,
+            ),
+            tokenizer=TokenizerArgs(nanotron_checkpoint_path),
+        )
+        log_rank("Saving config ...", logger=logger, level=logging.INFO, rank=0)
+        yaml.dump(config.as_dict(), f)
+
+    with open(nanotron_checkpoint_path / "model_config.json", "w") as f:
+        log_rank("Saving model config ...", logger=logger, level=logging.INFO, rank=0)
+        json.dump(asdict(nanotron_llama_config), f)
+
+    log_rank(
+        f"Checkpoint conversion finished, check {args.nanotron_checkpoint_path}",
+        logger=logger,
+        level=logging.INFO,
+        rank=0,
+    )
+
+
+if __name__ == "__main__":
+    _args = get_args()
+    main(_args)

--- a/tools/converters/convert_nanotron_to_hf.py
+++ b/tools/converters/convert_nanotron_to_hf.py
@@ -1,0 +1,221 @@
+"""
+torchrun --nproc-per-node 1 tools/converters/convert_nanotron_to_hf.py --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B --hugging-face-checkpoint-path checkpoints/huggingface_converted/Converted-Nanotron-Llama-3.2-3B
+"""
+import argparse
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+from nanotron import logging
+from nanotron.config import Config, LoggingArgs, ParallelismArgs, get_config_from_file
+from nanotron.logging import log_rank, set_ranks_logging_level
+from nanotron.models import build_model
+from nanotron.models.llama import LlamaForTraining
+from nanotron.parallel import ParallelContext
+from nanotron.parallel.parameters import sanity_check
+from nanotron.serialize import load_weights
+from nanotron.trainer import mark_tied_parameters
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.models.llama import LlamaConfig as LlamaConfigHF
+
+logger = logging.get_logger(__name__)
+
+DEVICE = torch.device("cpu")
+TORCH_DTYPE = torch.bfloat16
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="Nanotron Model")
+    group.add_argument(
+        "--nanotron-checkpoint-path",
+        type=str,
+        required=True,
+        help="A path to a directory with a Nanotron Checkpoint",
+    )
+
+    group = parser.add_argument_group(title="HuggingFace Model")
+    group.add_argument(
+        "--hugging-face-checkpoint-path",
+        type=str,
+        required=True,
+        help="A path to a directory to store the converted checkpoint",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+    # Init Nanotron Parallel Utilities
+    parallel_config = ParallelismArgs(dp=1, pp=1, tp=1)
+
+    parallel_context = ParallelContext(
+        data_parallel_size=parallel_config.dp,
+        pipeline_parallel_size=parallel_config.pp,
+        tensor_parallel_size=parallel_config.tp,
+    )
+
+    set_ranks_logging_level(parallel_context=parallel_context, logging_config=LoggingArgs())
+
+    # Load Nanotron checkpoint config
+    log_rank(
+        f"Loading Nanotron checkpoint config file: {os.path.join(args.nanotron_checkpoint_path, 'config.yaml')}",
+        logger=logger,
+        level=logging.INFO,
+        rank=0,
+    )
+    nanotron_config = get_config_from_file(
+        os.path.join(args.nanotron_checkpoint_path, "config.yaml"), config_class=Config, model_config_class=None
+    )
+    nanotron_llama_config = nanotron_config.model.model_config
+
+    # Init Llama3-8B Nanotron model
+    log_rank("Init empty Nanotron Llama3 Model", logger=logger, level=logging.INFO, rank=0)
+
+    nanotron_model = build_model(
+        model_builder=lambda: LlamaForTraining(
+            config=nanotron_config.model.model_config,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=TORCH_DTYPE,
+        device=DEVICE,
+    )
+
+    mark_tied_parameters(model=nanotron_model, parallel_context=parallel_context)
+    sanity_check(root_module=nanotron_model)
+
+    # Load Nanotron Checkpoint
+    log_rank("Loading Nanotron Llama3 Model...", logger=logger, level=logging.INFO, rank=0)
+    load_weights(
+        model=nanotron_model, parallel_context=parallel_context, root_folder=Path(args.nanotron_checkpoint_path)
+    )
+
+    # Build empty HF Model
+    log_rank("Init empty HF Llama3 Model", logger=logger, level=logging.INFO, rank=0)
+    hf_model = AutoModelForCausalLM.from_config(  # WARN This takes a long time
+        config=LlamaConfigHF(**asdict(nanotron_llama_config)),
+        torch_dtype=TORCH_DTYPE,
+        attn_implementation="flash_attention_2",
+    ).to(DEVICE)
+
+    # Copy params from Nanotron to HF
+    log_rank("Copying weights from Nanotron model to HF model...", logger=logger, level=logging.INFO, rank=0)
+    with torch.no_grad():
+        # Token embeddings
+        log_rank("Copying Token Embeddings...", logger=logger, level=logging.INFO, rank=0)
+        assert (
+            nanotron_model.model.token_position_embeddings.pp_block.token_embedding.weight.shape
+            == hf_model.model.embed_tokens.weight.shape
+        )
+        hf_model.model.embed_tokens.weight.copy_(
+                nanotron_model.model.token_position_embeddings.pp_block.token_embedding.weight
+            )
+
+        # Decoder layers
+        for i in tqdm(
+            range(nanotron_llama_config.num_hidden_layers),
+            desc="Copying Hidden Layers",
+            total=nanotron_llama_config.num_hidden_layers,
+        ):
+            # Input layer norm
+            assert (
+                hf_model.model.layers[i].input_layernorm.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.input_layernorm.weight.shape
+            )
+            hf_model.model.layers[i].input_layernorm.weight.copy_(
+                    nanotron_model.model.decoder[i].pp_block.input_layernorm.weight
+                )
+
+            # Self attn
+            # Split Nanotrn qkv projection into q, k, v
+            q, k, v = torch.split(
+                nanotron_model.model.decoder[i].pp_block.attn.qkv_proj.weight,
+                [
+                    nanotron_llama_config.num_attention_heads * nanotron_model.model.decoder[i].pp_block.attn.d_qk,
+                    nanotron_llama_config.num_key_value_heads * nanotron_model.model.decoder[i].pp_block.attn.d_qk,
+                    nanotron_llama_config.num_key_value_heads * nanotron_model.model.decoder[i].pp_block.attn.d_qk,
+                ],
+            )
+            assert q.shape == hf_model.model.layers[i].self_attn.q_proj.weight.shape
+            assert k.shape == hf_model.model.layers[i].self_attn.k_proj.weight.shape
+            assert v.shape == hf_model.model.layers[i].self_attn.v_proj.weight.shape
+
+            hf_model.model.layers[i].self_attn.q_proj.weight.copy_(q)
+            hf_model.model.layers[i].self_attn.k_proj.weight.copy_(k)
+            hf_model.model.layers[i].self_attn.v_proj.weight.copy_(v)
+
+            ## O
+            assert (
+                hf_model.model.layers[i].self_attn.o_proj.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.attn.o_proj.weight.shape
+            )
+            hf_model.model.layers[i].self_attn.o_proj.weight.copy_(
+                    nanotron_model.model.decoder[i].pp_block.attn.o_proj.weight
+                )
+
+            # MLP
+            ## Gate Up Proj
+            gate_proj, up_proj = torch.split(
+                nanotron_model.model.decoder[i].pp_block.mlp.gate_up_proj.weight,
+                split_size_or_sections=[nanotron_llama_config.intermediate_size, nanotron_llama_config.intermediate_size],
+            )
+            assert gate_proj.shape == hf_model.model.layers[i].mlp.gate_proj.weight.shape
+            assert up_proj.shape == hf_model.model.layers[i].mlp.up_proj.weight.shape
+
+            hf_model.model.layers[i].mlp.gate_proj.weight.copy_(gate_proj)
+            hf_model.model.layers[i].mlp.up_proj.weight.copy_(up_proj)
+
+            ## Down Proj
+            assert (
+                hf_model.model.layers[i].mlp.down_proj.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.mlp.down_proj.weight.shape
+            )
+            hf_model.model.layers[i].mlp.down_proj.weight.copy_(
+                    nanotron_model.model.decoder[i].pp_block.mlp.down_proj.weight
+                )
+
+            # Post attn layer norm
+            assert (
+                hf_model.model.layers[i].post_attention_layernorm.weight.shape
+                == nanotron_model.model.decoder[i].pp_block.post_attention_layernorm.weight.shape
+            )
+            hf_model.model.layers[i].post_attention_layernorm.weight.copy_(
+                    nanotron_model.model.decoder[i].pp_block.post_attention_layernorm.weight
+                )
+
+        # Last layer norm
+        log_rank("Copying Final Layer Norm...", logger=logger, level=logging.INFO, rank=0)
+        assert nanotron_model.model.final_layer_norm.pp_block.weight.shape == hf_model.model.norm.weight.shape
+        hf_model.model.norm.weight.copy_(nanotron_model.model.final_layer_norm.pp_block.weight)
+
+        # LM_Head
+        log_rank("Copying LM Head...", logger=logger, level=logging.INFO, rank=0)
+        assert nanotron_model.model.lm_head.pp_block.weight.shape == hf_model.lm_head.weight.shape
+        hf_model.lm_head.weight.copy_(nanotron_model.model.lm_head.pp_block.weight)
+
+    log_rank("Copied weights from Nanotron model to HF model!", logger=logger, level=logging.INFO, rank=0)
+    # Store weights
+    log_rank("Storing HF model Checkpoint and Tokenizer!", logger=logger, level=logging.INFO, rank=0)
+    hf_model.save_pretrained(args.hugging_face_checkpoint_path, from_pt=True)
+    # Store tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(nanotron_config.tokenizer.tokenizer_name_or_path)
+    tokenizer.save_pretrained(args.hugging_face_checkpoint_path)
+
+    log_rank(
+        f"Checkpoint conversion finished, check {args.hugging_face_checkpoint_path}",
+        logger=logger,
+        level=logging.INFO,
+        rank=0,
+    )
+
+
+if __name__ == "__main__":
+    _args = get_args()
+    main(_args)

--- a/tools/converters/delete/generate_hf_predictions.py
+++ b/tools/converters/delete/generate_hf_predictions.py
@@ -1,0 +1,73 @@
+"""
+torchrun --nproc-per-node 1 tools/converters/delete/generate_hf_predictions.py --pretrained-model-name-or-path meta-llama/Llama-3.2-3B
+"""
+import argparse
+import os
+
+import numpy as np
+import torch
+from sklearn.metrics import accuracy_score
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+TXT="Paris! Paris is the capital and most populous city of France, located in the north-central part of the country. It is a global center for art, fashion, cuisine, culture, and romance. Here's a brief overview: **History and Culture:**Paris has a rich history dating back to the 3rd century, with a blend of Roman, Gothic, Renaissance, and Art Nouveau influences. The city is famous for its iconic landmarks like the Eiffel Tower (built for the 1889 World's Fair), the Louvre Museum (home to the Mona Lisa), Notre-Dame Cathedral, and the Arc de Triomphe. **Art and Architecture:**Paris is renowned for its stunning architecture, with many beautiful bridges, gardens, and buildings. The city is also a hub for art, with numerous museums, galleries, and street performers. The Louvre, Musée d'Orsay, and Centre Pompidou are just a few of the many world-class museums. **Fashion and Cuisine:**Paris is considered the fashion capital of the world, with top designers like Chanel, Dior, and Louis Vuitton. The city is also famous for its exquisite cuisine, with popular dishes like escargots, croissants, baguettes, and cheese. Don't forget to try a classic French dessert like crème brûlée or macarons! **Romance and Entertainment:**Paris is often called the City of Light (La Ville Lumière) and the City of Love. It's a popular destination for couples and honeymooners, with its picturesque Seine River, charming streets, and cozy cafes. The city also hosts many festivals and events, including the French Open tennis tournament, the Tour de France, and the Rock en Seine music festival. **Economy and Education:** Paris is a global economic hub, with many multinational companies, startups, and universities. The city is home to some of the world's top universities, including the Sorbonne and École des Hautes Études en Sciences Sociales (EHESS). **Tourism:** Paris is one of the most visited cities in the world, attracting over 23 million tourists annually. Visitors come to experience the city's unique blend of history, culture, art, fashion, and romance. In summary, Paris is a vibrant, elegant, and enchanting city that offers something for everyone: history, art, fashion, cuisine, romance, and entertainment."
+SEQ_LENGTH = 256  # For truncating the TXT if GPU can't fit too many tokens
+
+DEVICE = torch.device("cuda")
+TORCH_DTYPE = torch.bfloat16
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="HuggingFace Model")
+    group.add_argument(
+        "--pretrained-model-name-or-path",
+        type=str,
+        required=True,
+        help="A path to a directory containing model weights saved using save_pretrained() or the model id of a pretrained model hosted inside a model repo on the Hugging Face Hub",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.pretrained_model_name_or_path,
+        torch_dtype=TORCH_DTYPE,
+        attn_implementation="flash_attention_2",
+    ).to(DEVICE).eval()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model_name_or_path)
+    tokens = tokenizer(TXT, return_tensors="pt", truncation=True, max_length=(SEQ_LENGTH + 1))["input_ids"].to(DEVICE)
+    inputs = tokens[:, :-1]
+
+    with torch.no_grad():
+        output = model(inputs)
+
+    predicted_tokens = [5, 27, 34]  # Index of the predictions to compare across models
+    term_cols = int(os.get_terminal_size().columns / 3)
+
+    for predicted_token in predicted_tokens:
+
+        print("\n", "=" * term_cols, f"Predictions of token {predicted_token}", "=" * term_cols)
+        next_tokens = torch.softmax(output.logits[0, predicted_token, :], -1)
+        topk_next_tokens = torch.topk(next_tokens, 10)
+
+        print(
+            *[
+                f"[HF Model] Next token: {idx.item()}, probability: {prob}"
+                for idx, prob in zip(topk_next_tokens.indices, topk_next_tokens.values)
+            ],
+            sep="\n",
+        )
+
+    # Compute accuracy
+    predictions = np.argmax(output.logits.to(torch.float).cpu(), axis=2).flatten().tolist()
+    labels = tokens.cpu().flatten()[1:].tolist()
+    print(f"\nAccuracy: {accuracy_score(labels, predictions)}")
+
+if __name__ == "__main__":
+    _args = get_args()
+    main(_args)

--- a/tools/converters/delete/generate_nanotron_predictions.py
+++ b/tools/converters/delete/generate_nanotron_predictions.py
@@ -1,0 +1,127 @@
+"""
+torchrun --nproc-per-node 1 tools/converters/delete/generate_nanotron_predictions.py --tp 1 --nanotron-checkpoint-path /capstor/scratch/cscs/asolergi/nanotron/checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B
+"""
+import argparse
+import os
+from pathlib import Path
+
+import nanotron.distributed as dist
+import numpy as np
+import torch
+from nanotron.config import Config, ParallelismArgs, get_config_from_file
+from nanotron.models import build_model
+from nanotron.models.llama import LlamaForTraining
+from nanotron.parallel import ParallelContext
+from nanotron.parallel.parameters import sanity_check
+from nanotron.parallel.pipeline_parallel.engine import AllForwardAllBackwardPipelineEngine
+from nanotron.parallel.tensor_parallel.nn import TensorParallelLinearMode
+from nanotron.serialize import load_weights
+from nanotron.trainer import mark_tied_parameters
+from sklearn.metrics import accuracy_score
+from transformers import AutoTokenizer
+
+TXT="Paris! Paris is the capital and most populous city of France, located in the north-central part of the country. It is a global center for art, fashion, cuisine, culture, and romance. Here's a brief overview: **History and Culture:**Paris has a rich history dating back to the 3rd century, with a blend of Roman, Gothic, Renaissance, and Art Nouveau influences. The city is famous for its iconic landmarks like the Eiffel Tower (built for the 1889 World's Fair), the Louvre Museum (home to the Mona Lisa), Notre-Dame Cathedral, and the Arc de Triomphe. **Art and Architecture:**Paris is renowned for its stunning architecture, with many beautiful bridges, gardens, and buildings. The city is also a hub for art, with numerous museums, galleries, and street performers. The Louvre, Musée d'Orsay, and Centre Pompidou are just a few of the many world-class museums. **Fashion and Cuisine:**Paris is considered the fashion capital of the world, with top designers like Chanel, Dior, and Louis Vuitton. The city is also famous for its exquisite cuisine, with popular dishes like escargots, croissants, baguettes, and cheese. Don't forget to try a classic French dessert like crème brûlée or macarons! **Romance and Entertainment:**Paris is often called the City of Light (La Ville Lumière) and the City of Love. It's a popular destination for couples and honeymooners, with its picturesque Seine River, charming streets, and cozy cafes. The city also hosts many festivals and events, including the French Open tennis tournament, the Tour de France, and the Rock en Seine music festival. **Economy and Education:** Paris is a global economic hub, with many multinational companies, startups, and universities. The city is home to some of the world's top universities, including the Sorbonne and École des Hautes Études en Sciences Sociales (EHESS). **Tourism:** Paris is one of the most visited cities in the world, attracting over 23 million tourists annually. Visitors come to experience the city's unique blend of history, culture, art, fashion, and romance. In summary, Paris is a vibrant, elegant, and enchanting city that offers something for everyone: history, art, fashion, cuisine, romance, and entertainment."
+SEQ_LENGTH = 256  # For truncating the TXT if GPU can't fit too many tokens
+
+DEVICE = torch.device("cuda")
+TORCH_DTYPE = torch.bfloat16
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="Nanotron Model")
+    group.add_argument(
+        "--nanotron-checkpoint-path",
+        type=str,
+        required=True,
+        help="A path to a directory containing a Nanotron Checkpoint",
+    )
+
+    group = parser.add_argument_group(title="Nanotron Parallelism")
+    group.add_argument("--tp", type=int, required=True, help="Tensor Parallelism Degree of the Nanotron Checkpoint")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+    # Init Nanotron Parallel Utilities
+    parallel_config = ParallelismArgs(
+        dp=1,
+        pp=1,
+        tp=args.tp,
+        pp_engine=AllForwardAllBackwardPipelineEngine(),
+        tp_mode=TensorParallelLinearMode.ALL_REDUCE,
+        tp_linear_async_communication=False,
+    )
+    assert (
+        parallel_config.tp_mode == TensorParallelLinearMode.ALL_REDUCE
+        and parallel_config.tp_linear_async_communication is False
+    )
+
+    parallel_context = ParallelContext(
+        data_parallel_size=parallel_config.dp,
+        pipeline_parallel_size=parallel_config.pp,
+        tensor_parallel_size=parallel_config.tp,
+    )
+
+    RANK = dist.get_rank(parallel_context.world_pg)
+
+    nanotron_config = get_config_from_file(
+        os.path.join(args.nanotron_checkpoint_path, "config.yaml"), config_class=Config, model_config_class=None
+    )
+
+    model = build_model(
+        model_builder=lambda: LlamaForTraining(
+            config=nanotron_config.model.model_config,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=TORCH_DTYPE,
+        device=DEVICE,  # TODO Check with different parallelism if cpu is available
+    )
+
+    mark_tied_parameters(model=model, parallel_context=parallel_context)
+    sanity_check(root_module=model)
+
+    # Load checkpoint directly in memory and then only keep the state dictionary
+    load_weights(model=model, parallel_context=parallel_context, root_folder=Path(args.nanotron_checkpoint_path))
+
+    tokenizer = AutoTokenizer.from_pretrained(nanotron_config.tokenizer.tokenizer_name_or_path)
+    tokens = tokenizer(TXT, return_tensors="pt", truncation=True, max_length=(SEQ_LENGTH + 1))["input_ids"].to(DEVICE)
+    inputs = {"input_ids": tokens[:, :-1], "input_mask": torch.ones((1, SEQ_LENGTH), device=DEVICE)}
+
+    model.eval()
+
+    with torch.no_grad():
+        output = model.model(**inputs)
+
+    if not RANK:
+        predicted_tokens = [5, 27, 34]  # Index of the predictions to compare across models
+        term_cols = int(os.get_terminal_size().columns / 3)
+
+        for predicted_token in predicted_tokens:
+
+            print("\n", "=" * term_cols, f"Predictions of token {predicted_token}", "=" * term_cols)
+            next_tokens = torch.softmax(output.transpose(0, 1)[0, predicted_token, :], -1)
+            topk_next_tokens = torch.topk(next_tokens, 10)
+
+            print(
+                *[
+                    f"[Nanotron Model] Next token: {idx.item()}, probability: {prob}"
+                    for idx, prob in zip(topk_next_tokens.indices, topk_next_tokens.values)
+                ],
+                sep="\n",
+            )
+
+        # Compute accuracy
+        predictions = np.argmax(output.transpose(0, 1).to(torch.float).cpu(), axis=2).flatten().tolist()
+        labels = tokens.cpu().flatten()[1:].tolist()
+        print(f"\nAccuracy: {accuracy_score(labels, predictions)}")
+
+if __name__ == "__main__":
+    _args = get_args()
+    main(_args)


### PR DESCRIPTION
Hi! 

In this branch I reintroduce & update to the current main branch the Llama model & conversion scripts to support Llama3.1 and Llama3.2 1B&3B models.
The main changes are the following:
1. Deleted Flash Attention RoPEs as they don't support rope scaling of Llama3
2. Copied + Cleaning `transformers` [LlamaRotaryEmbedding](https://github.com/huggingface/transformers/blob/0b5b5e6a70249837293499e9363a64765a57111c/src/transformers/models/llama/modeling_llama.py#L84) layer. Now this will be the only class in llama.py. I think it shouldn't break generations for the inference case WITHOUT `LlamaConfig.rope_interleaved = True` in `CausalSelfAttention.forward`, are there any tests?
3. Added @eliebak fixes (#253) to just load weights from a checkpoint. I would suggest adding a `config.optimizer.finetuning` flag in order to (True) just load the weights or (False) Load weights, optimizer & LR Scheduler instead of `config.checkpoints.load_optimizer` & `config.checkpoints.load_lr_scheduler`
4. Switched from `flash_attn_varlen_func` to `flash_attn_func` as the later achieves greater performance. Keep in mind that we aren't using any feature of the varlen funct so it's recommended to stick with `flash_attn_func`
5. Should we depreciate `LlamaConfig.rope_interleaved` ? It was useful for training when using FlashAttention RoPEs and now seems to be used also in the inference code. IMO we should unify all 3 cases (Training, inference with rope_interleaved & inference without rope interleaved) within a single RoPE

## Results
You can run the conversions & generations tests using the scripts in `tools/converters`. As I already mentioned in the previous PR (#174), despite we need at least 1 GPU (To init the `ParallelContext`) we are running the conversion with the CPU.
1. Generate HF predictions with the HF Hub model
```
torchrun --nproc-per-node 1 tools/converters/delete/generate_hf_predictions.py --pretrained-model-name-or-path meta-llama/Llama-3.2-3B
```
2. Convert the HF model to Nanotron
```
torchrun --nproc-per-node 1 tools/converters/convert_hf_to_nanotron.py --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B --pretrained-model-name-or-path meta-llama/Llama-3.2-3B
```
3. Generate predictions with the nanotron converted model
```
torchrun --nproc-per-node 1 tools/converters/delete/generate_nanotron_predictions.py --tp 1 --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B
```
4. Convert the model back to HF
```
torchrun --nproc-per-node 1 tools/converters/convert_nanotron_to_hf.py --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B --hugging-face-checkpoint-path checkpoints/huggingface_converted/Converted-Nanotron-Llama-3.2-3B
```
5. Generate predictions using the converted back HF model
```
torchrun --nproc-per-node 1 tools/converters/delete/generate_hf_predictions.py --pretrained-model-name-or-path checkpoints/huggingface_converted/Converted-Nanotron-Llama-3.2-3B
```

As can be seen from the following table, we observe slightly differences between the 2 backends. Those differences are produced by the QKV projections in the CausalSelfAttention layer (Nanotron computes them in a single GEMM vs 3 different GEMMs in HF) and the LayerNorm layer is different (Nanotron is using a optimized one from FlashAttention vs Basic PyTorch LayerNorm in HF). Also note that the differences increase if we use TP which is totally expected as the sizes of the GEMMs are different, triggering different GEMM algorithms. 

|                           Experiment                           |  Backend | Size |     TP     | Accuracy |
|:--------------------------------------------------------------:|:--------:|:----:|:----------:|:--------:|
|                              OG HF                             |    HF    |   3  |      1     |   0.73046875   |
|                      OG HF --&gt; Nanotron                     | Nanotron |   3  |      1     |   0.7265625   |
|                 OG HF --&gt; Nanotron --&gt; HF                |    HF    |   3  |      1     |   0.73046875   |
|                      OG HF --&gt; Nanotron                     | Nanotron |   3  |      2     |   0.703125   |
|                      OG HF --&gt; Nanotron                     | Nanotron |   3  |      4     |   0.65234375   |

To run the Nanotron generations with different TP sizes:
```
torchrun --nproc-per-node 2 tools/converters/delete/generate_nanotron_predictions.py --tp 2 --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B
torchrun --nproc-per-node 4 tools/converters/delete/generate_nanotron_predictions.py --tp 4 --nanotron-checkpoint-path checkpoints/nanotron_pretrained_checkpoints/Nanotron-Llama-3.2-3B
```

TODO (Preferably in other PRs):
- [ ] Edit examples/config_llama3.2-3B.yaml data_stages.data.dataset.dataset_folder
- [ ] Remove `nanotron/tools/converters/delete/generate_hf_predictions.py` & `nanotron/tools/converters/delete/generate_nanotron_predictions.py` scripts
- [ ] Integrate Liger kernels for `apply_rotary_pos_emb`
- [ ] Switch to SDPA instead of FA2
- [ ] Reduce number of transposes in `CausalSelfAttention.forward`