### PR TITLE
Fix wrong initialization of lr scheduler

### DIFF
--- a/src/nanotron/serialize/main.py
+++ b/src/nanotron/serialize/main.py
@@ -60,6 +60,7 @@ def save(
     should_save_lr_scheduler: bool = True,
     sanity_checks: bool = True,
 ) -> None:
+
     assert isinstance(training_metadata, TrainingMetadata)
 
     try:
@@ -107,6 +108,7 @@ def save(
                 lr_scheduler=lr_scheduler,
                 parallel_context=parallel_context,
                 root_folder=root_folder,
+                is_zero=config.optimizer.zero_stage
             )
     except Exception as e:
         log_rank(

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -190,6 +190,13 @@ class DistributedTrainer:
             optimizer_args=self.config.optimizer,
             parallel_context=self.parallel_context,
         )
+        
+        # Init learning rate scheduler
+        self.lr_scheduler = lr_scheduler_builder(
+            optimizer=self.optimizer,
+            lr_scheduler_args=self.config.optimizer.learning_rate_scheduler,
+            total_training_steps=self.config.tokens.train_steps,
+        )
         if self.init_checkpoint_path is not None:
             load_optimizer(
                 optimizer=self.optimizer,
@@ -199,13 +206,6 @@ class DistributedTrainer:
                 model=self.unwrapped_model,
                 map_location="cpu",
             )
-
-        # Init learning rate scheduler
-        self.lr_scheduler = lr_scheduler_builder(
-            optimizer=self.optimizer,
-            lr_scheduler_args=self.config.optimizer.learning_rate_scheduler,
-            total_training_steps=self.config.tokens.train_steps,
-        )
         if self.init_checkpoint_path is not None:
             load_lr_scheduler(
                 lr_scheduler=self.lr_scheduler,


### PR DESCRIPTION
The initialization of the learning rate scheduler does not correctly resume. This is because the optimizer state is loaded first, and the lambda in the LR scheduler is partialied to the LR this implies. In this PR I fix(?) it by first initializing both the optimizer and the LR scheduler, then load the state dict for each. 

So, for example, when you save the state dict at a step you have 
```
lr_scheduler.lr_lambdas[0]
functools.partial(<function lr_scheduler_builder.<locals>.lr_lambda at 0x7f6e1c539fc0>, initial_lr=0.0003)
```

but when you reload it to resume you have 
```
lr_scheduler.lr_lambdas[0]
functools.partial(<function lr_scheduler_builder.<locals>.lr_lambda at 0x7f00c053b760>, initial_lr=1e-05)
```

Obviously, using a totally wrong LR schedule makes resumption useless. 

It seems to work, except for the 15 step example `examples/config_tiny_llama.yaml`, where it's close to working, but not exact. I'm assuming this is due to some sort of warm up or something. If it's not clear to you I can look into it further. 

Plus a small fix for the code just not running in `serialize/main.py`. 