### PR TITLE
Updating dependency versions in pyproject.toml and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Nanotron is a library for pretraining transformer models. It provides a simple a
 ## Installation
 
 ```bash
-# Requirements: Python>=3.10
+# Requirements: Python>=3.10,<3.12
 git clone https://github.com/huggingface/nanotron
 cd nanotron
 pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "torch>=1.13.1",
     "pyyaml",
-    "numpy",
+    "numpy<2",
     "packaging",
     "safetensors",
     "dacite",
@@ -45,7 +45,7 @@ test = [
 ]
 
 fast-modeling = [
-    "flash-attn>=2.5.0",
+    "flash-attn>=2.5.0,<2.7.0",
 ]
 
 nanosets = [


### PR DESCRIPTION
Hi,

I was trying to get the example in the README to run, and encountered a few issues. They were eventually resolved through dependency version changes, so I thought I'd make a PR.

**README change — specifying <python 3.12** 
This was motivated by the following issue that I faced when using Python 3.12.
<img width="827" alt="python importerror caused by version incompatibility" src="https://github.com/user-attachments/assets/9ea84607-765d-4d8d-874f-c84f410f2520">

**pyproject.toml changes — specified flash-attn<2.70**
In the upcoming flash-attn 2.7.0, the return format for `bert_padding.unpad_input` was changed, which causes the example to fail with flash-attn 2.7.0.

Screenshot of commit changing return format from flash-attn repo:
<img width="532" alt="commit message from flash-attn repository showing the change" src="https://github.com/user-attachments/assets/09c8e999-9801-42fa-9933-8270e6a108bf">

**pyproject.toml changes — specified numpy<2**
NumPy 2 had some breaking changes, and one of those changes seems to break the serializing in nanotron. This is illustrated in the screenshot below, where a numpy int seems to have been saved as `np.int64(48)` instead of 48. Specifying numpy<2 solves this issue. 

Screenshot of issue:
<img width="715" alt="illustration of issue caused by numpy 2" src="https://github.com/user-attachments/assets/393c536d-9aa1-4d72-b044-9e2c0057dad4">

Thanks!


