### PR TITLE
Add context manager to increase NCCL timeout temporarily

### DIFF
--- a/src/nanotron/utils.py
+++ b/src/nanotron/utils.py
@@ -82,6 +82,24 @@ def local_ranks_zero_first(group: Optional[dist.ProcessGroup] = None):
         yield
 
 
+@contextmanager
+def nccl_timeout_override(timeout_ms: int):
+    """Context manager that temporarily increases the NCCL timeout.
+    """
+    # Save the original timeout value
+    original_timeout = os.environ.get('NCCL_TIMEOUT_MS', None)
+    os.environ['NCCL_TIMEOUT_MS'] = str(timeout_ms)
+
+    try:
+        yield
+    finally:
+        # Restore the original timeout value
+        if original_timeout is not None:
+            os.environ['NCCL_TIMEOUT_MS'] = original_timeout
+        else:
+            del os.environ['NCCL_TIMEOUT_MS']
+
+
 def checkpoint_method(attr_name: str):
     """Decorator to checkpoint a method of a class."""
 


### PR DESCRIPTION
When using an HF dataset, the NCCL timeout may trigger before the first device finishes tokenizing the input data. This commit adds a context manager to increase it temporarily. I used a value of 1h, which should be enough for processing 10BT datasets.

Users should still prefer the usage of Nanosets to tokenize the dataset before running the training script.