### PR TITLE
Recommend the use of Spack on supercomputers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ pip install triton "flash-attn>=2.5.0" --no-build-isolation
 > [!NOTE]
 > If you get `undefined symbol: ncclCommRegister` error you should install torch 2.1.2 instead: `pip install torch==2.1.2 --index-url https://download.pytorch.org/whl/cu121`
 
+On supercomputers, prefer the usage of Spack to install Nanotron:
+
+```bash
+git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
+cd spack/bin
+./spack install py-nanotron
+```
+
 > [!TIP]
 > We log to wandb automatically if it's installed. For that you can use `pip install wandb`. If you don't want to use wandb, you can run `wandb disabled`.
 


### PR DESCRIPTION
Supercomputers often require specific versions of software or custom builds tailored to their architecture. Spack allows to manage complex HPC stacks in a reproducible manner.

This PR documents the process of installing Nanotron using Spack.

I added Spack support for Nanotron in this PR: https://github.com/spack/spack/pull/48582. The command `spack install py-nanotron` will install the last published release v0.4. Use `spack install py-nanotron@main` to install the last commit.