### PR TITLE
[Feature] Over 99% communication overlap in Tensor Parallelism using Domino

### DIFF
--- a/examples/domino_tiny_llama.yaml
+++ b/examples/domino_tiny_llama.yaml
@@ -1,0 +1,98 @@
+checkpoints:
+  checkpoint_interval: 2000
+  checkpoints_path: checkpoints
+  checkpoints_path_is_shared_file_system: false
+  resume_checkpoint_path: null
+  save_initial_state: false
+data_stages:
+- data:
+    dataset:
+      dataset_overwrite_cache: false
+      dataset_processing_num_proc_per_process: 1
+      hf_dataset_config_name: null
+      hf_dataset_or_datasets: stas/openwebtext-10k
+      hf_dataset_splits: train
+      text_column_name: text
+    num_loading_workers: 1
+    seed: 42
+  name: Stable Training Stage
+  start_training_step: 1
+general:
+  benchmark_csv_path: null
+  consumed_train_samples: null
+  ignore_sanity_checks: true
+  project: debug
+  run: tiny_llama_%date_%jobid
+  seed: 42
+  step: null
+lighteval: null
+logging:
+  iteration_step_info_interval: 1
+  log_level: info
+  log_level_replica: info
+model:
+  ddp_bucket_cap_mb: 25
+  dtype: bfloat16
+  init_method:
+    std: 0.025
+  make_vocab_size_divisible_by: 1
+  model_config:
+    bos_token_id: 1
+    eos_token_id: 2
+    hidden_act: silu
+    hidden_size: 4096 #16
+    initializer_range: 0.02
+    intermediate_size: 14336 #64
+    is_llama_config: true
+    max_position_embeddings: 2048 #256
+    num_attention_heads: 32 #4
+    num_hidden_layers: 8 #32 #2
+    num_key_value_heads: 8
+    pad_token_id: null
+    pretraining_tp: 1
+    rms_norm_eps: 1.0e-05
+    rope_scaling: null
+    tie_word_embeddings: true
+    use_cache: true
+    vocab_size: 1024 #256
+optimizer:
+  accumulate_grad_in_fp32: true
+  clip_grad: 1.0
+  learning_rate_scheduler:
+    learning_rate: 0.0003
+    lr_decay_starting_step: null
+    lr_decay_steps: 13
+    lr_decay_style: cosine
+    lr_warmup_steps: 2
+    lr_warmup_style: linear
+    min_decay_lr: 1.0e-05
+  optimizer_factory:
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    name: adamW
+    torch_adam_is_fused: true
+  weight_decay: 0.01
+  zero_stage: 0
+parallelism:
+  dp: 1
+  expert_parallel_size: 1
+  pp: 1
+  pp_engine: 1f1b
+  tp: 2
+  tp_linear_async_communication: false
+  tp_mode: ALL_REDUCE
+profiler: null
+  # profiler_export_path: /home/code/profile
+tokenizer:
+  tokenizer_max_length: null
+  tokenizer_name_or_path: robot-test/dummy-tokenizer-wordlevel
+  tokenizer_revision: null
+tokens:
+  batch_accumulation_per_replica: 1
+  limit_test_batches: 0
+  limit_val_batches: 0
+  micro_batch_size: 16
+  sequence_length: 2048 #256
+  train_steps: 50
+  val_check_interval: -1

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -40,6 +40,7 @@ from nanotron.parallel.tensor_parallel.nn import (
     TensorParallelLinearMode,
     TensorParallelRowLinear,
     RowLinearNoComm,
+    DominoColumnLinear,
 )
 from nanotron.random import RandomStates
 from nanotron.scaling.parametrization import SpectralMupParametrizator, StandardParametrizator
@@ -225,16 +226,31 @@ class MLP(nn.Module):
             config.intermediate_size,  # shape of gate_linear
             config.intermediate_size,  # shape of up_linear
         )
-        self.gate_up_proj = TensorParallelColumnLinear(
-            config.hidden_size,
-            2 * config.intermediate_size,
-            pg=tp_pg,
-            mode=tp_mode,
-            bias=False,
-            async_communication=tp_linear_async_communication,
-            contiguous_chunks=gate_up_contiguous_chunks,
-            tp_recompute_allgather=parallel_config.tp_recompute_allgather,
-        )
+
+        if USE_DOMINO:
+            self.gate_up_proj = DominoColumnLinear(
+                config.hidden_size,
+                2 * config.intermediate_size,
+                pg=tp_pg,
+                mode=tp_mode,
+                bias=False,
+                async_communication=tp_linear_async_communication,
+                contiguous_chunks=gate_up_contiguous_chunks,
+                tp_recompute_allgather=parallel_config.tp_recompute_allgather,
+            )
+        else:
+            self.gate_up_proj = TensorParallelColumnLinear(
+                config.hidden_size,
+                2 * config.intermediate_size,
+                pg=tp_pg,
+                mode=tp_mode,
+                bias=False,
+                async_communication=tp_linear_async_communication,
+                contiguous_chunks=gate_up_contiguous_chunks,
+                tp_recompute_allgather=parallel_config.tp_recompute_allgather,
+            )
+
+        
         if USE_DOMINO:
             self.down_proj = RowLinearNoComm(
             config.intermediate_size,
@@ -396,16 +412,30 @@ class CausalSelfAttention(nn.Module, AttachableStore):
             config.num_key_value_heads * self.d_qk,  # shape of k
             config.num_key_value_heads * self.d_qk,  # shape of v
         )
-        self.qkv_proj = TensorParallelColumnLinear(
-            self.d_model,
-            config.num_attention_heads * self.d_qk + 2 * config.num_key_value_heads * self.d_qk,
-            pg=tp_pg,
-            mode=tp_mode,
-            bias=False,
-            async_communication=tp_linear_async_communication,
-            contiguous_chunks=qkv_contiguous_chunks,
-            tp_recompute_allgather=parallel_config.tp_recompute_allgather,
-        )
+
+        if USE_DOMINO:
+            self.qkv_proj = DominoColumnLinear(
+                self.d_model,
+                config.num_attention_heads * self.d_qk + 2 * config.num_key_value_heads * self.d_qk,
+                pg=tp_pg,
+                mode=tp_mode,
+                bias=False,
+                async_communication=tp_linear_async_communication,
+                contiguous_chunks=qkv_contiguous_chunks,
+                tp_recompute_allgather=parallel_config.tp_recompute_allgather,
+            )
+        else:
+            self.qkv_proj = TensorParallelColumnLinear(
+                self.d_model,
+                config.num_attention_heads * self.d_qk + 2 * config.num_key_value_heads * self.d_qk,
+                pg=tp_pg,
+                mode=tp_mode,
+                bias=False,
+                async_communication=tp_linear_async_communication,
+                contiguous_chunks=qkv_contiguous_chunks,
+                tp_recompute_allgather=parallel_config.tp_recompute_allgather,
+            )
+
         # TODO(kunhao): We want to have only one version per device and not one version per layer.
         if config.rope_interleaved:
             self.rotary_embedding = RotaryEmbedding(
@@ -943,39 +973,60 @@ class LlamaModel(nn.Module):
 
         # raise ValueError
         
-        
+        torch.cuda.nvtx.range_push("Forward transformer layers")
 
         # for encoder_block in self.decoder:
         #     hidden_encoder_states = encoder_block(**hidden_encoder_states)
+        fwd_handle0, fwd_handle1 = None, None
+        residual0, residual1 = None, None
 
-        for encoder_block in self.decoder:
+        for index, encoder_block in enumerate(self.decoder):
             # print(encoder_block.__class__)
+            if index > 0:
+                fwd_handle0.wait()
+                hidden_states0 = hidden_states0 + residual0
+
             residual0 = hidden_states0
             hidden_states0 = encoder_block.pp_block.input_layernorm(hidden_states0)
             output0 = encoder_block.pp_block.attn(hidden_states=hidden_states0, sequence_mask=seq_mask0)
             hidden_states0 = output0["hidden_states"]
-            torch.distributed.all_reduce(hidden_states0, group=self.parallel_context.tp_pg)
-            hidden_states0 = hidden_states0 + residual0
+            fwd_handle0 = torch.distributed.all_reduce(hidden_states0, group=self.parallel_context.tp_pg, async_op=True)
+            
+            if index > 0:
+                fwd_handle1.wait()
+                hidden_states1 = hidden_states1 + residual1
 
             residual1 = hidden_states1
             hidden_states1 = encoder_block.pp_block.input_layernorm(hidden_states1)
             output1 = encoder_block.pp_block.attn(hidden_states=hidden_states1, sequence_mask=seq_mask1)
             hidden_states1 = output1["hidden_states"]
-            torch.distributed.all_reduce(hidden_states1, group=self.parallel_context.tp_pg)
-            hidden_states1 = hidden_states1 + residual1
+            fwd_handle1 = torch.distributed.all_reduce(hidden_states1, group=self.parallel_context.tp_pg, async_op=True)
+            
 
+            fwd_handle0.wait()
+            hidden_states0 = hidden_states0 + residual0
             residual0 = hidden_states0
             hidden_states0 = encoder_block.pp_block.post_attention_layernorm(hidden_states0)
             hidden_states0 = encoder_block.pp_block.mlp(hidden_states=hidden_states0)["hidden_states"]
-            torch.distributed.all_reduce(hidden_states0, group=self.parallel_context.tp_pg)
-            hidden_states0 = hidden_states0 + residual0
+            # torch.distributed.all_reduce(hidden_states0, group=self.parallel_context.tp_pg)
+            fwd_handle0 = torch.distributed.all_reduce(hidden_states0, group=self.parallel_context.tp_pg, async_op=True)
+            
 
+            fwd_handle1.wait()
+            hidden_states1 = hidden_states1 + residual1
             residual1 = hidden_states1
             hidden_states1 = encoder_block.pp_block.post_attention_layernorm(hidden_states1)
             hidden_states1 = encoder_block.pp_block.mlp(hidden_states=hidden_states1)["hidden_states"]
-            torch.distributed.all_reduce(hidden_states1, group=self.parallel_context.tp_pg)
-            hidden_states1 = hidden_states1 + residual1
+            # torch.distributed.all_reduce(hidden_states1, group=self.parallel_context.tp_pg)
+            fwd_handle1 = torch.distributed.all_reduce(hidden_states1, group=self.parallel_context.tp_pg, async_op=True)
 
+        fwd_handle0.wait()
+        hidden_states0 = hidden_states0 + residual0
+        
+        fwd_handle1.wait()
+        hidden_states1 = hidden_states1 + residual1
+
+        torch.cuda.nvtx.range_pop()
 
         hidden_states = torch.cat([hidden_states0, hidden_states1], dim=1)
 

--- a/src/nanotron/parallel/tensor_parallel/functional.py
+++ b/src/nanotron/parallel/tensor_parallel/functional.py
@@ -345,6 +345,68 @@ class _ColumnLinearAsyncCommunication(torch.autograd.Function):
             raise ValueError(f"Got unexpected mode: {tp_mode}.")
 
 
+class _DominoColumnLinearAsyncCommunication(torch.autograd.Function):
+    """Adapted from https://github.com/NVIDIA/Megatron-LM/blob/e6d7e09845590d0a36bc7f29eb28db974fb8da4e/megatron/core/tensor_parallel/layers.py#L215"""
+
+    @staticmethod
+    @assert_cuda_max_connections_set_to_1
+    def forward(ctx, inp, weight, bias, group, tp_mode):
+        ctx.use_bias = bias is not None
+        ctx.tp_mode = tp_mode
+        ctx.group = group
+        # ctx.tp_recompute_allgather = tp_recompute_allgather
+        ctx.tensor_shape =inp.size()
+        ctx.save_for_backward(inp, weight)
+        return F.linear(inp, weight, bias)
+
+                
+
+    @staticmethod
+    @assert_cuda_max_connections_set_to_1
+    def backward(ctx, grad_output):
+        total_tensor, weight = ctx.saved_tensors
+        group = ctx.group
+        use_bias = ctx.use_bias
+        tp_mode = ctx.tp_mode
+
+
+        grad_tensor = grad_output.matmul(weight)
+
+        handle = torch.distributed.all_reduce(grad_tensor, group=group, async_op=True)
+
+        # Doing gather + slicing during the NeMo forward pass can make this tensor
+        # not be contiguous. PyTorch only checks if the tensor is contiguous, and only
+        # clones it if it's not contiguous:
+        # https://github.com/pytorch/pytorch/blob/c47cf9bc7f9e02f649ab4ed53fe4d35732c92ab6/torch/_refs/__init__.py#L2761
+        grad_output = grad_output.contiguous()
+        # Convert the tensor shapes to 2D for execution compatibility
+        grad_output_first_dims, grad_output_last_dim = grad_output.shape[:-1], grad_output.shape[-1]
+        total_tensor_first_dims, total_tensor_last_dim = total_tensor.shape[:-1], total_tensor.shape[-1]
+        grad_output = grad_output.view(math.prod(grad_output_first_dims), grad_output_last_dim)
+        total_tensor = total_tensor.view(math.prod(total_tensor_first_dims), total_tensor_last_dim)
+
+
+        grad_bias = grad_output.sum(dim=0) if use_bias else None
+
+        
+
+        # TODO @thomasw21: This sounds like we don't have the optimal physical layout
+        grad_weight = grad_output.t().matmul(total_tensor)
+
+        handle.wait()
+
+        return grad_tensor, grad_weight, grad_bias, None, None, None
+
+
+
+
+
+
+
+
+
+
+
 class _ColumnLinearNoAsyncCommunicationReduceScatterMode(torch.autograd.Function):
     """
     Column linear with memory_buffer for the allgather, context parallel

--- a/src/nanotron/parallel/tensor_parallel/functional.py
+++ b/src/nanotron/parallel/tensor_parallel/functional.py
@@ -354,7 +354,6 @@ class _DominoColumnLinearAsyncCommunication(torch.autograd.Function):
         ctx.use_bias = bias is not None
         ctx.tp_mode = tp_mode
         ctx.group = group
-        # ctx.tp_recompute_allgather = tp_recompute_allgather
         ctx.tensor_shape =inp.size()
         ctx.save_for_backward(inp, weight)
         return F.linear(inp, weight, bias)
@@ -385,12 +384,8 @@ class _DominoColumnLinearAsyncCommunication(torch.autograd.Function):
         grad_output = grad_output.view(math.prod(grad_output_first_dims), grad_output_last_dim)
         total_tensor = total_tensor.view(math.prod(total_tensor_first_dims), total_tensor_last_dim)
 
-
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
-        
-
-        # TODO @thomasw21: This sounds like we don't have the optimal physical layout
         grad_weight = grad_output.t().matmul(total_tensor)
 
         handle.wait()

--- a/src/nanotron/parallel/tensor_parallel/nn.py
+++ b/src/nanotron/parallel/tensor_parallel/nn.py
@@ -147,17 +147,7 @@ class DominoColumnLinear(nn.Linear):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-
-        return _DominoColumnLinearAsyncCommunication.apply(x, self.weight, self.bias, self.pg, self.mode)        
-        # return column_linear(
-        #     input=x,
-        #     weight=self.weight,
-        #     bias=self.bias,
-        #     group=self.pg,
-        #     tp_mode=self.mode,
-        #     async_communication=self.async_communication,
-        #     tp_recompute_allgather=self.tp_recompute_allgather,
-        # )
+        return _DominoColumnLinearAsyncCommunication.apply(x, self.weight, self.bias, self.pg, self.mode)
 
     def extra_repr(self) -> str:
         return f"tp_rank={dist.get_rank(self.pg)}, {super().extra_repr()}, unsharded_out_features={self.out_features * self.world_size}"

--- a/src/nanotron/scaling/parametrization.py
+++ b/src/nanotron/scaling/parametrization.py
@@ -9,6 +9,7 @@ from nanotron.parallel.tensor_parallel.nn import (
     TensorParallelColumnLinear,
     TensorParallelEmbedding,
     TensorParallelRowLinear,
+    RowLinearNoComm,
 )
 from torch import nn
 from torch.nn import init
@@ -36,6 +37,7 @@ class StandardParametrizator(Parametrizator):
         self.MODULE_TO_PARAMETRIZE = {
             TensorParallelColumnLinear: self._parametrize_column_linear,
             TensorParallelRowLinear: self._parametrize_row_linear,
+            RowLinearNoComm: self._parametrize_row_linear,
             TritonRMSNorm: self._parametrize_layer_norm,
             TensorParallelEmbedding: self._parametrize_embedding,
         }

--- a/src/nanotron/scaling/parametrization.py
+++ b/src/nanotron/scaling/parametrization.py
@@ -10,6 +10,7 @@ from nanotron.parallel.tensor_parallel.nn import (
     TensorParallelEmbedding,
     TensorParallelRowLinear,
     RowLinearNoComm,
+    DominoColumnLinear,
 )
 from torch import nn
 from torch.nn import init
@@ -36,6 +37,7 @@ class StandardParametrizator(Parametrizator):
         super().__init__(config)
         self.MODULE_TO_PARAMETRIZE = {
             TensorParallelColumnLinear: self._parametrize_column_linear,
+            DominoColumnLinear: self._parametrize_column_linear,
             TensorParallelRowLinear: self._parametrize_row_linear,
             RowLinearNoComm: self._parametrize_row_linear,
             TritonRMSNorm: self._parametrize_layer_norm,


### PR DESCRIPTION
Hi nanotron team,  this is the follow-up work of #285. This PR implements the cross layer communication computation overlapping,  and it can achieve over 99% communication overlapping on single node. Using Domino, TP training on single node is almost communication "free". 

### Profiling results

Forward pass
  
![image](https://github.com/user-attachments/assets/78a72d0b-50af-485c-9f35-283d4d2b5c24)

Backward pass
![image](https://github.com/user-attachments/assets/d580b46a-8a82-40c8-b5bb-dc66abc98a3f)

Please note that the flag enabling Domino is hardcoded [here](https://github.com/hwchen2017/nanotron/blob/hongwei_domino_cross_layer_overlap/src/nanotron/models/llama.py#L52). It needs to be configurable for ease of use, but I haven't done it yet. There might also be other considerations on your side. You can further improve the code quality based on this branch. Please let me know if you have any other questions.

Cc: @GuanhuaWang
