### PR TITLE
fix: allow conversion from checkpoints trained with llama.py or qwen.py

### DIFF
--- a/examples/llama/convert_nanotron_to_hf.py
+++ b/examples/llama/convert_nanotron_to_hf.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Literal, Optional, Type
 
 import torch
-from nanotron.config import LlamaConfig as NanotronLlamaConfig
+from nanotron.config import LlamaConfig as NanotronLlamaConfig, Qwen2Config as NanotronQwen2Config
 from nanotron.config import NanotronConfigs
 from nanotron.models import init_on_device_and_dtype
 from nanotron.models.llama import LlamaForTraining
@@ -162,11 +162,19 @@ if __name__ == "__main__":
     parser.add_argument("--checkpoint_path", type=Path, default="llama-7b", help="Path to the checkpoint")
     parser.add_argument("--save_path", type=Path, default="llama-7b-hf", help="Path to save the HF model")
     parser.add_argument("--tokenizer_name", type=str, default="meta-llama/Llama-2-7b-chat-hf")
+    parser.add_argument("--config_cls", type=str, default="LlamaConfig", help="Config class to use for conversion (Either LlamaConfig or Qwen2Config)")
     args = parser.parse_args()
+
+    if args.config_cls == "LlamaConfig":
+        config_cls = NanotronLlamaConfig
+    elif args.config_cls == "Qwen2Config":
+        config_cls = NanotronQwen2Config
+    else:
+        raise ValueError(f"Invalid config class: {args.config_cls}. Should be one of [NanotronLlamaConfig, NanotronQwen2Config]")
 
     # Convert Nanotron model to HF format.
     convert_checkpoint_and_save(
-        checkpoint_path=args.checkpoint_path, save_path=args.save_path, tokenizer_name=args.tokenizer_name
+        checkpoint_path=args.checkpoint_path, save_path=args.save_path, tokenizer_name=args.tokenizer_name, config_cls=config_cls
     )
 
     # Check if the conversion was successful by generating some text.

--- a/run_evals.py
+++ b/run_evals.py
@@ -16,6 +16,7 @@ from lighteval.main_nanotron import nanotron
 def create_lighteval_config(
     output_dir: str = "./eval_results",
     tasks: str = "lighteval|agieval:aqua-rat|5|0",
+    custom_tasks: str = None,
     batch_size: int = 16,
     dp: int = 1,
     pp: int = 1,
@@ -67,7 +68,7 @@ def create_lighteval_config(
     # Create tasks config
     tasks_args = LightEvalTasksArgs(
         tasks=tasks,
-        custom_tasks=None,
+        custom_tasks=custom_tasks,
         max_samples=max_samples,
         dataset_loading_processes=8,
         multichoice_continuations_start_space=None,
@@ -192,9 +193,10 @@ if __name__ == "__main__":
         # Create a custom config
         custom_config = create_lighteval_config(
             output_dir="./eval_results/custom",
-            tasks="lighteval|agieval:aqua-rat|5|0",
+            tasks="custom|hellaswag|0|1,custom|winogrande|0|1,custom|piqa|0|1,custom|siqa|0|1,custom|openbookqa|0|1,custom|arc:easy|0|1,custom|arc:challenge|0|1,custom|commonsense_qa|0|1,custom|mmlu:abstract_algebra|0|1,custom|mmlu:anatomy|0|1,custom|mmlu:astronomy|0|1,custom|mmlu:business_ethics|0|1,custom|mmlu:clinical_knowledge|0|1,custom|mmlu:college_biology|0|1,custom|mmlu:college_chemistry|0|1,custom|mmlu:college_computer_science|0|1,custom|mmlu:college_mathematics|0|1,custom|mmlu:college_medicine|0|1,custom|mmlu:college_physics|0|1,custom|mmlu:computer_security|0|1,custom|mmlu:conceptual_physics|0|1,custom|mmlu:econometrics|0|1,custom|mmlu:electrical_engineering|0|1,custom|mmlu:elementary_mathematics|0|1,custom|mmlu:formal_logic|0|1,custom|mmlu:global_facts|0|1,custom|mmlu:high_school_biology|0|1,custom|mmlu:high_school_chemistry|0|1,custom|mmlu:high_school_computer_science|0|1,custom|mmlu:high_school_european_history|0|1,custom|mmlu:high_school_geography|0|1,custom|mmlu:high_school_government_and_politics|0|1,custom|mmlu:high_school_macroeconomics|0|1,custom|mmlu:high_school_mathematics|0|1,custom|mmlu:high_school_microeconomics|0|1,custom|mmlu:high_school_physics|0|1,custom|mmlu:high_school_psychology|0|1,custom|mmlu:high_school_statistics|0|1,custom|mmlu:high_school_us_history|0|1,custom|mmlu:high_school_world_history|0|1,custom|mmlu:human_aging|0|1,custom|mmlu:human_sexuality|0|1,custom|mmlu:international_law|0|1,custom|mmlu:jurisprudence|0|1,custom|mmlu:logical_fallacies|0|1,custom|mmlu:machine_learning|0|1,custom|mmlu:management|0|1,custom|mmlu:marketing|0|1,custom|mmlu:medical_genetics|0|1,custom|mmlu:miscellaneous|0|1,custom|mmlu:moral_disputes|0|1,custom|mmlu:moral_scenarios|0|1,custom|mmlu:nutrition|0|1,custom|mmlu:philosophy|0|1,custom|mmlu:prehistory|0|1,custom|mmlu:professional_accounting|0|1,custom|mmlu:professional_law|0|1,custom|mmlu:professional_medicine|0|1,custom|mmlu:professional_psychology|0|1,custom|mmlu:public_relations|0|1,custom|mmlu:security_studies|0|1,custom|mmlu:sociology|0|1,custom|mmlu:us_foreign_policy|0|1,custom|mmlu:virology|0|1,custom|mmlu:world_religions|0|1",
+            custom_tasks="/fsx/jason/interleaved/custom_tasks.py",
             batch_size=8,
-            dp=8,
+            dp=1,
             pp=1,
             tp=1,
             max_samples=50,  # Use a small number for testing


### PR DESCRIPTION
# What does this PR do?
Allows `convert_nanotron_to_hf.py` to convert checkpoints trained with `Qwen2Config` as well as `LlamaConfig`.

I was getting the following error when trying to convert a checkpoint trained with qwen.py:

```
Traceback (most recent call last):
  File "/fsx/jason/miniconda3/envs/interleaved/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/fsx/jason/miniconda3/envs/interleaved/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/fsx/jason/interleaved/nanotron/examples/llama/convert_nanotron_to_hf.py", line 176, in <module>
    convert_checkpoint_and_save(
  File "/fsx/jason/interleaved/nanotron/examples/llama/convert_nanotron_to_hf.py", line 128, in convert_checkpoint_and_save
    model_config = config_cls(**attrs)
TypeError: LlamaConfig.__init__() got an unexpected keyword argument 'is_qwen2_config'
```

So I added a new flag to the conversion script that allows you to specify config class

```
 --config_cls CONFIG_CLS
                        Config class to use for conversion (Either LlamaConfig or Qwen2Config)
```

It defaults to LlamaConfig so this is not a breaking change.




## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@NouamaneTazi 