### PR TITLE
reshape rotary_part

### DIFF
--- a/src/nanotron/nn/rotary.py
+++ b/src/nanotron/nn/rotary.py
@@ -123,10 +123,10 @@ class RotaryEmbedding(nn.Module):
             self.sin_values = (torch.sin(freqs) * mscale).to(tensor.dtype)
 
         # Apply rotary embedding
+        rotary_part = rotary_part.view(
+            -1, seq_length, rotary_part.shape[1], rotary_part.shape[2]
+        )  # [b, s, nheads, dim/2]
         if self.fused:
-            rotary_part = rotary_part.view(
-                -1, seq_length, rotary_part.shape[1], rotary_part.shape[2]
-            )  # [b, s, nheads, dim/2]
             rotated_tensor = flash_apply_rotary_emb(
                 rotary_part, self.cos_values, self.sin_values, interleaved=self.interleaved, inplace=True
             )


### PR DESCRIPTION
# What does this PR do?
we need to reshape `rotary_part` in the non fused case as well otherwise we get shapes mismatch
```bash
  rotated_tensor = (rotary_part * self.cos_values.unsqueeze(1)) + (
[default3]:[rank59]: RuntimeError: The size of tensor a (12288) must match the size of tensor b (4096) at non-singleton dimension 0
[default4]:[rank60]:     q = self.rotary_emb.apply_rotary_pos_emb(
[default4]:[rank60]:   File "/fsx/loubna/projects_v2/benchmarks/nouamane_pr/nanotron/src/nanotron/nn/rotary.py", line 135, in apply_rotary_pos_emb
[default4]:[rank60]:     rotated_tensor = (rotary_part * self.cos_values.unsqueeze(1)) + (
[default4]:[rank60]: RuntimeError: The size of tensor a (12288) must match the size of tensor b (4096) at non-singleton dimension 0
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guidelines](https://github.com/huggingface/nanotron/blob/main/CONTRIBUTING.md#submitting-a-new-issue-or-feature-request)?
- [ ] Did you write any new necessary tests?
- [ ] Did you log the throughput and loss you get to ensure the PR works as expected in actual training?
- [ ] Did you log the memory usage? you can use [this tool](https://huggingface.co/spaces/nanotron/predict_memory) to understand the memory usage breakdown in nanotron.
- [ ] If you modified anything related to checkpoints, did you verify that saving and reloading checkpoints still works correctly?



## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @ -->