### PR TITLE
[Feature] Implement CUDA event-based timing for improved GPU performa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CUDA_DEVICE_MAX_CONNECTIONS=1 torchrun --nproc_per_node=8 run_train.py --config-
 The model will be saved in the `checkpoints` directory as specified in the config file.
 
 > [!NOTE]
-> You can use `examples/config_tiny_llama.py` to generate your own training config 
+> You can use `examples/config_tiny_llama.py` to generate your own training config
 
 For detailed instructions on training your first model, check out our [Your First Training guide](docs/your-first-training.md). For multi-node training with Slurm, see our [Multi-Node Training guide](docs/multi-node-training.md).
 
@@ -173,6 +173,7 @@ We currently support the following features:
 - [x] Custom module checkpointing for large models
 - [x] Spectral µTransfer parametrization for scaling up neural networks
 - [x] Mamba example
+- [x] CUDA event-based timing for accurate GPU performance measurement
 
 And we have on our roadmap:
 - [ ] FP8 training

--- a/docs/cuda_event_timing.md
+++ b/docs/cuda_event_timing.md
@@ -1,0 +1,74 @@
+# CUDA Event-Based Timing in Nanotron
+
+## Overview
+
+Nanotron now uses CUDA events for timing GPU operations instead of CPU-based timing with `time.time()`. This change provides several benefits:
+
+1. **More accurate measurement of GPU execution time**: CUDA events are recorded directly on the GPU timeline, providing more precise timing of GPU operations.
+2. **Reduced need for explicit CUDA synchronization**: CPU-based timing requires synchronization between CPU and GPU to get accurate measurements, which can introduce overhead and affect performance.
+3. **Lower overhead**: CUDA event-based timing has minimal impact on the execution of GPU operations.
+4. **Better performance monitoring**: More accurate timing leads to better performance analysis and optimization.
+
+## Implementation Details
+
+The implementation uses `torch.cuda.Event` with `enable_timing=True` to create start and end events that are recorded on the GPU timeline. The elapsed time is then calculated using `start_event.elapsed_time(end_event)`, which returns the time in milliseconds.
+
+### Key Changes
+
+1. **Default Timer Type**: The default timer type in `nanotron/src/nanotron/logging/timers.py` has been changed from `TimerType.CPU` to `TimerType.CUDA`.
+
+2. **Iteration Timing**: The iteration timing in `trainer.py` now uses CUDA events instead of `time.time()`.
+
+3. **Synchronization Control**: By default, CUDA event-based timers do not force synchronization unless explicitly requested with `cuda_sync=True`.
+
+## Usage
+
+### Basic Usage
+
+```python
+# Create and use a CUDA timer (default)
+with nanotron_timer("my_operation"):
+    # Your GPU operation here
+    ...
+
+# Explicitly specify CUDA timing
+with nanotron_timer("my_operation", timer_type="cuda"):
+    # Your GPU operation here
+    ...
+
+# For CPU-only operations, you can still use CPU-based timing
+with nanotron_timer("cpu_operation", timer_type="cpu"):
+    # Your CPU operation here
+    ...
+```
+
+### Advanced Usage
+
+```python
+# Start and end a timer manually
+timer = nanotron_timer("my_operation")
+timer.start()
+# Your operation here
+timer.end()
+
+# Get the elapsed time in seconds
+elapsed_time = timer.elapsed
+
+# Get the total time across all calls
+total_time = timer.total_time
+
+# Get the average time per call
+avg_time = timer.average_time
+```
+
+## Considerations
+
+1. **Synchronization**: By default, CUDA event-based timers do not force synchronization to avoid overhead. If you need more accurate timing at the cost of performance, you can set `cuda_sync=True`.
+
+2. **Units**: CUDA events measure time in milliseconds, but the timer API converts this to seconds for consistency with the previous CPU-based timing.
+
+3. **Fallback**: If CUDA is not available, the timer will automatically fall back to CPU-based timing.
+
+## Performance Impact
+
+Using CUDA events for timing instead of CPU-based timing with synchronization can significantly reduce overhead, especially in distributed training scenarios with thousands of GPUs.

--- a/docs/cuda_event_timing.md
+++ b/docs/cuda_event_timing.md
@@ -40,6 +40,24 @@ with nanotron_timer("my_operation", timer_type="cuda"):
 with nanotron_timer("cpu_operation", timer_type="cpu"):
     # Your CPU operation here
     ...
+
+# As a decorator with default CUDA timing
+@nanotron_timer
+def my_function():
+    # Your GPU operation here
+    ...
+
+# As a decorator with custom name
+@nanotron_timer("custom_name")
+def my_function():
+    # Your GPU operation here
+    ...
+
+# As a decorator with CPU timing
+@nanotron_timer(timer_type=TimerType.CPU)
+def my_cpu_function():
+    # Your CPU operation here
+    ...
 ```
 
 ### Advanced Usage

--- a/src/nanotron/logging/timers.py
+++ b/src/nanotron/logging/timers.py
@@ -19,10 +19,17 @@ class TimerType(Enum):
 
 @dataclass
 class TimerRecord:
-    """Records timing information for a single timer."""
+    """
+    Records timing information for a single timer.
+
+    By default, uses CUDA events for timing GPU operations, which provides more accurate
+    measurements of GPU execution time without forcing CPU-GPU synchronization.
+
+    For CPU-only operations, you can use CPU-based timing by specifying timer_type=TimerType.CPU.
+    """
 
     name: str
-    timer_type: TimerType = TimerType.CPU
+    timer_type: TimerType = TimerType.CUDA
     start_time: float = 0.0
     end_time: float = 0.0
     running: bool = False
@@ -175,7 +182,17 @@ class TimerRecord:
 
 
 class Timers:
-    """A collection of timers for tracking execution time in Nanotron."""
+    """
+    A collection of timers for tracking execution time in Nanotron.
+
+    By default, timers use CUDA events for timing GPU operations, which provides several benefits:
+    1. More accurate measurement of GPU execution time
+    2. Reduced need for explicit CUDA synchronization
+    3. Lower overhead compared to CPU-based timing with synchronization
+    4. Better performance monitoring for distributed training
+
+    For CPU-only operations, you can still use CPU-based timing by specifying timer_type=TimerType.CPU.
+    """
 
     _instance = None
     _enabled = os.environ.get("ENABLE_TIMERS", "0") == "1"  # Add global enable/disable flag
@@ -202,7 +219,7 @@ class Timers:
         return cls._enabled
 
     def __call__(
-        self, name: str, timer_type: Union[TimerType, str] = TimerType.CPU, cuda_sync: bool = True
+        self, name: str, timer_type: Union[TimerType, str] = TimerType.CUDA, cuda_sync: bool = False
     ) -> TimerRecord:
         """Get or create a timer with the given name.
 
@@ -213,9 +230,10 @@ class Timers:
 
         Args:
             name: Name of the timer
-            timer_type: Type of timer, either TimerType.CPU or TimerType.CUDA
-                        (or 'cpu'/'cuda' strings)
-            cuda_sync: Whether to perform torch.cuda.synchronize() for more accurate CUDA timing
+            timer_type: Type of timer, either TimerType.CUDA (default) or TimerType.CPU
+                        (or 'cuda'/'cpu' strings)
+            cuda_sync: Whether to perform torch.cuda.synchronize() for more accurate CUDA timing.
+                       Default is False to avoid unnecessary synchronization overhead.
         """
         if not self._enabled:
             # Return a dummy timer that does nothing when timing is disabled
@@ -224,11 +242,11 @@ class Timers:
         if isinstance(timer_type, str):
             timer_type = TimerType(timer_type)
 
-        if callable(name) and timer_type == TimerType.CPU:
+        if callable(name) and timer_type == TimerType.CUDA:
             # Being used as a decorator with default settings
             func = name
             timer_name = func.__name__
-            return self._create_timer_decorator(timer_name, TimerType.CPU, cuda_sync)(func)
+            return self._create_timer_decorator(timer_name, TimerType.CUDA, cuda_sync)(func)
 
         if name not in self._timers:
             self._timers[name] = TimerRecord(name=name, timer_type=timer_type, cuda_sync=cuda_sync)
@@ -245,7 +263,7 @@ class Timers:
         # If we get here, we're being called as @nanotron_timer("name", timer_type)
         return self._create_timer_decorator(name, timer_type, cuda_sync)
 
-    def _create_timer_decorator(self, name, timer_type, cuda_sync=False):
+    def _create_timer_decorator(self, name, timer_type=TimerType.CUDA, cuda_sync=False):
         """Create a decorator that times the execution of a function."""
 
         def decorator(func):

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -371,33 +371,31 @@ class DistributedTrainer:
             elif world_rank == self.logger_ranks[0]:
                 run_name = f"{current_time}_{self.config.general.run}"
                 x_stats_sampling_interval = os.environ.get("STATS_SAMPLING_INTERVAL_IN_SEC", None)
+
+                wandb_settings = {}
+
+                if x_stats_sampling_interval is not None:
+                    wandb_settings["x_stats_sampling_interval"] = float(x_stats_sampling_interval)
+                    wandb_settings["x_stats_open_metrics_endpoints"] = {
+                        "dcgm": "http://localhost:9104/metrics",
+                        "node": "http://localhost:9100/metrics",
+                        "lustre": "http://localhost:9106/metrics",
+                        "gpu": "http://26.0.168.238:9103/metrics",
+                        "efa": "http://localhost:9101/metrics",
+                    }
+                    wandb_settings["x_stats_open_metrics_filters"] = [
+                        "DCGM_FI_",
+                        "node_",
+                        "lustre_",
+                        "nvidia_gpu_",
+                        "efa_",
+                    ]
+
                 wandb.init(
                     project=self.config.general.project,
                     name=run_name,
                     config={"nanotron_config": self.config.as_dict()},
-                    settings=wandb.Settings(
-                        x_stats_sampling_interval=float(x_stats_sampling_interval)
-                        if x_stats_sampling_interval is not None
-                        else None,
-                        x_stats_open_metrics_endpoints={
-                            "dcgm": "http://localhost:9104/metrics",
-                            "node": "http://localhost:9100/metrics",
-                            "lustre": "http://localhost:9106/metrics",
-                            "gpu": "http://26.0.168.238:9103/metrics",
-                            "efa": "http://localhost:9101/metrics",
-                        }
-                        if x_stats_sampling_interval is not None
-                        else None,
-                        x_stats_open_metrics_filters=[
-                            "DCGM_FI_",
-                            "node_",
-                            "lustre_",
-                            "nvidia_gpu_",
-                            "efa_",
-                        ]
-                        if x_stats_sampling_interval is not None
-                        else None,
-                    ),
+                    settings=wandb.Settings(**wandb_settings),
                 )
                 # save config file
                 temp_config_path = tempfile.mktemp(suffix=".yaml", prefix="config")

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -275,6 +275,7 @@ class DistributedTrainer:
         self.limit_val_batches = self.config.tokens.limit_val_batches
         self.current_dataloader: Optional[DataLoader] = None  # used for the current training stage
         self.current_base_dl: Optional[DataLoader] = None  # used for the current training stage
+        self.iteration_timer = None  # Will be initialized during training
 
         log_libraries_versions(logger=logger)
         log_rank("Config:", logger=logger, level=logging.INFO, rank=0, is_separator=True)
@@ -554,7 +555,9 @@ class DistributedTrainer:
                     logger.info(f"Profiler on for step {self.iteration_step}")
                     prof.step()
 
-                self.iteration_start_time = time.time()
+                # Use CUDA event-based timing for more accurate GPU-side elapsed time measurement
+                self.iteration_timer = nanotron_timer("iteration_time", "cuda", cuda_sync=False)
+                self.iteration_timer.start()
                 self._update_dataloader_based_on_training_stages(dataloader_or_dls)
 
                 # Training step
@@ -738,8 +741,9 @@ class DistributedTrainer:
     ) -> None:
         # TODO @nouamanetazi: Megatron-LM seems to be using a barrier to report their interval time. Check if this is necessary. https://github.com/NouamaneTazi/Megatron-LM/blob/e241a96c3085b18e36c6cee1d68a8155de77b5a6/megatron/training.py#L607
         dist.barrier()
-        torch.cuda.synchronize()
-        elapsed_time_per_iteration_ms = (time.time() - self.iteration_start_time) * 1000
+        # End the iteration timer and get elapsed time in milliseconds
+        self.iteration_timer.end()
+        elapsed_time_per_iteration_ms = self.iteration_timer.elapsed * 1000
         tokens_per_sec = (
             self.global_batch_size * self.sequence_length / (elapsed_time_per_iteration_ms / 1000)
         )  # tokens_per_sec is calculated using sequence_length

--- a/test_timer_decorator.py
+++ b/test_timer_decorator.py
@@ -1,0 +1,63 @@
+"""Test script for the timer decorator with both CPU and CUDA timer types."""
+
+from nanotron.logging.timers import nanotron_timer, TimerType
+import time
+import torch
+
+# Enable timers for testing
+nanotron_timer.enable()
+
+# Test with default CUDA timing
+@nanotron_timer
+def test_default_decorator():
+    """Test function with default CUDA timing."""
+    # Simulate some work
+    time.sleep(0.1)
+    if torch.cuda.is_available():
+        x = torch.randn(1000, 1000, device="cuda")
+        y = torch.matmul(x, x)
+        torch.cuda.synchronize()
+    return "Done"
+
+# Test with explicit CUDA timing
+@nanotron_timer(timer_type=TimerType.CUDA)
+def test_cuda_decorator():
+    """Test function with explicit CUDA timing."""
+    # Simulate some work
+    time.sleep(0.1)
+    if torch.cuda.is_available():
+        x = torch.randn(1000, 1000, device="cuda")
+        y = torch.matmul(x, x)
+        torch.cuda.synchronize()
+    return "Done"
+
+# Test with CPU timing
+@nanotron_timer(timer_type=TimerType.CPU)
+def test_cpu_decorator():
+    """Test function with CPU timing."""
+    # Simulate some CPU work
+    time.sleep(0.2)
+    return "Done"
+
+# Test with custom name
+@nanotron_timer("custom_name")
+def test_custom_name_decorator():
+    """Test function with custom name."""
+    # Simulate some work
+    time.sleep(0.1)
+    return "Done"
+
+if __name__ == "__main__":
+    print("Testing timer decorators...")
+    
+    # Run the test functions
+    test_default_decorator()
+    test_cuda_decorator()
+    test_cpu_decorator()
+    test_custom_name_decorator()
+    
+    # Log all timers
+    print("\nTimer results:")
+    nanotron_timer.log_all(rank=None)  # Log on all ranks
+    
+    print("\nTest completed successfully!")


### PR DESCRIPTION
# What does this PR do?

This PR implements GPU-native timing by replacing CPU-based timers with CUDA event-based timing. This change reduces overhead and improves precision during distributed training by minimizing synchronization between CPU and GPU.

Fixes #88

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guidelines](https://github.com/huggingface/nanotron/blob/main/CONTRIBUTING.md#submitting-a-new-issue-or-feature-request)?
- [x] Did you write any new necessary tests?
- [x] Did you log the throughput and loss you get to ensure the PR works as expected in actual training?
- [x] Did you log the memory usage? you can use [this tool](https://huggingface.co/spaces/nanotron/predict_memory) to understand the memory usage breakdown in nanotron.
- [x] If you modified anything related to checkpoints, did you verify that saving and reloading checkpoints still works correctly?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Specifically tagging @xrsrke and @staghado for their expertise in this area.