### PR TITLE
SmolLM3 HF-to-nanotron conversion

### DIFF
--- a/examples/llama/convert_hf_to_nanotron_qwen.py
+++ b/examples/llama/convert_hf_to_nanotron_qwen.py
@@ -1,0 +1,143 @@
+"""
+Converts a HF model to nanotron format
+Command:
+    torchrun --nproc_per_node=1 examples/llama/convert_hf_to_nanotron_qwen.py --checkpoint_path=hf_weights --save_path=nanotron_weights
+"""
+
+import dataclasses
+import json
+import logging
+from argparse import ArgumentParser
+from pathlib import Path
+
+import yaml
+
+import nanotron
+import torch
+from nanotron.config import Qwen2Config as NanotronQwen2Config
+from transformers import AutoModelForCausalLM
+
+from convert_weights import get_config_mapping, get_weight_mapping, load_nanotron_model
+
+logger = logging.getLogger(__name__)
+
+
+def _handle_attention_block(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    n_q_heads: int,
+    n_kv_heads: int,
+    d_qk: int,
+    interleave: bool,
+) -> torch.Tensor:
+    # Huggingface Llama separates the q, k, v weights (as opposed to nanotron).
+    # Furthermore, in the rotary embeddings in nanotron expects interleaved pairs of even
+    # and odd dimensions GPT-J style, while the huggingface implementation expects
+    # the whole 1st half and then the whole 2nd half GPT-NeoX style (for more information
+    # see flash_attn.layers.rotary.RotaryEmbedding).
+    # This function handles the concatenation of the q, k, v weights and proper permutation
+    # to ensure correct transformation.
+
+    def interleave_weight(w: torch.Tensor):
+        w_new = []
+        for head_w in w.split(d_qk):
+            head_w = head_w.view(2, d_qk // 2, -1).transpose(0, 1).reshape(d_qk, -1)
+            w_new.append(head_w)
+        return torch.cat(w_new)
+
+    q = interleave_weight(q) if interleave else q
+    k = interleave_weight(k) if interleave else k
+    return torch.cat([q, k, v])
+
+
+def convert_hf_to_nt(model_hf, model_nt, config: NanotronQwen2Config, interleave_qkv: bool = False):
+    """Converts the weights from the model_hf to model_nt, making modifications
+    in-place."""
+
+    hf_sd = model_hf.state_dict()
+    nt_to_hf = get_weight_mapping(config, nt_to_hf=True)
+
+    for module_name_nt, module_nt in model_nt.named_modules():
+        for param_name_nt, param_nt in module_nt.named_parameters(recurse=False):
+            # In the case of qkv_proj, the nt_to_hf has exactly three keys, ccorresponding
+            # to q, k, v.
+            if "qkv_proj" in module_name_nt:
+                key_k, key_q, key_v = sorted(nt_to_hf[f"{module_name_nt}.{param_name_nt}"])
+                q = hf_sd[key_q]
+                k = hf_sd[key_k]
+                v = hf_sd[key_v]
+                param = _handle_attention_block(
+                    q,
+                    k,
+                    v,
+                    config.num_attention_heads,
+                    config.num_key_value_heads,
+                    config.hidden_size // config.num_attention_heads,
+                    interleave_qkv,
+                )
+            # The case of gate_up_proj, nt_to_hf_map has two keys.
+            elif "gate_up_proj" in module_name_nt:
+                key_gate, key_up = sorted(nt_to_hf[f"{module_name_nt}.{param_name_nt}"])
+                gate = hf_sd[key_gate]
+                up = hf_sd[key_up]
+                param = torch.cat([gate, up])
+            # All other cases are simple 1-to-1 correspondence.
+            else:
+                hf_key = nt_to_hf[f"{module_name_nt}.{param_name_nt}"]
+                param = hf_sd[hf_key]
+
+            with torch.no_grad():
+                param_nt.copy_(param)
+
+
+def get_nanotron_config(config) -> NanotronQwen2Config:
+    """Converts a huggingface configuration to nanotron Qwen2Config."""
+    defaults = {f.name: f.default for f in dataclasses.fields(NanotronQwen2Config) if f.default is not dataclasses.MISSING}
+    attrs = {}
+    for nt_key, hf_key in get_config_mapping(nt_to_hf=True).items():
+        if hasattr(config, hf_key):
+            attrs[nt_key] = getattr(config, hf_key)
+        else:
+            logger.warning(f"HF config missing '{hf_key}' -> '{nt_key}', using default: {defaults.get(nt_key, '?')}")
+
+    # Nanotron-specific: use packed QKV attention path (FlashRotaryEmbedding)
+    attrs.setdefault("_use_qkv_packed", True)
+
+    return NanotronQwen2Config(**attrs)
+
+
+def convert_checkpoint_and_save(checkpoint_path: Path, save_path: Path):
+    """Loads the huggingface checkpoint in `checkpoint_path`, creates
+    a new nanotron instance, copies the weights from the huggingface checkpoint
+    and saves the transformed nanotron to `save_path`."""
+
+    # Load huggingface.
+    hf_model = AutoModelForCausalLM.from_pretrained(checkpoint_path)
+
+    # Init nanotron model.
+    model_config = get_nanotron_config(hf_model.config)
+    nanotron_model = load_nanotron_model(model_config=model_config, config_cls=NanotronQwen2Config)
+
+    # Copy weights and save model.
+    parallel_context = nanotron.parallel.ParallelContext(
+        data_parallel_size=1, pipeline_parallel_size=1, tensor_parallel_size=1
+    )
+    convert_hf_to_nt(hf_model, nanotron_model, model_config)
+    nanotron.serialize.save_weights(model=nanotron_model, parallel_context=parallel_context, root_folder=save_path)
+    config_dict = dataclasses.asdict(model_config)
+    with open(save_path / "model_config.json", "w+") as f:
+        json.dump(config_dict, f)
+    with open(save_path / "model_config.yaml", "w+") as f:
+        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=True)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Convert HF weights to nanotron format")
+    parser.add_argument("--checkpoint_path", type=Path, default="llama-7b", help="Path to the checkpoint")
+    parser.add_argument("--save_path", type=Path, default="llama-7b-hf", help="Path to save the nanotron model")
+    args = parser.parse_args()
+
+    # Convert HF model to nanotron format.
+    convert_checkpoint_and_save(checkpoint_path=args.checkpoint_path, save_path=args.save_path)

--- a/examples/llama/convert_weights.py
+++ b/examples/llama/convert_weights.py
@@ -85,6 +85,7 @@ def get_config_mapping(nt_to_hf: bool = True) -> dict[str, str]:
         "vocab_size": "vocab_size",
         "attention_bias": "attention_bias",
         "rope_interleaved": "rope_interleaved",
+        "no_rope_layer_interval": "no_rope_layer",
     }
     if nt_to_hf:
         return {nt: hf for hf, nt in hf_to_nt_map.items()}

--- a/examples/llama/tests/test_smollm3_conversion.py
+++ b/examples/llama/tests/test_smollm3_conversion.py
@@ -1,0 +1,88 @@
+"""Logits matching test for SmolLM3-3B-Base HF->nanotron conversion.
+Mirrors test_conversion.py::test_hf_to_nt but avoids the tests.helpers import (MECAB conflict).
+"""
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+_this_file = Path(__file__).resolve()
+_nanotron_root = _this_file.parent.parent.parent.parent
+sys.path.insert(0, str(_nanotron_root))
+sys.path.insert(0, str(_this_file.parent))
+
+from utils import set_system_path
+
+set_system_path()
+
+import torch
+from transformers import AutoModelForCausalLM
+
+import nanotron
+from nanotron.config import Qwen2Config as NanotronQwen2Config
+from nanotron.models.qwen import Qwen2ForTraining
+from nanotron.parallel import ParallelContext
+from nanotron.random import set_random_seed
+from nanotron.trainer import mark_tied_parameters
+
+from examples.llama.convert_hf_to_nanotron_qwen import convert_hf_to_nt, get_nanotron_config
+from examples.llama.convert_weights import make_parallel_config
+
+set_random_seed(0)
+
+MODEL_NAME = "HuggingFaceTB/SmolLM3-3B-Base"
+BATCH_SIZE = 6
+SEQUENCE_LENGTH = 5
+ATOL = 0.03
+
+
+def create_nanotron_model(parallel_context, config):
+    parallel_config = make_parallel_config()
+    nanotron_model = nanotron.models.build_model(
+        model_builder=lambda: Qwen2ForTraining(
+            config=config,
+            parallel_context=parallel_context,
+            parallel_config=parallel_config,
+            random_states=None,
+        ),
+        parallel_context=parallel_context,
+        dtype=torch.bfloat16,
+        device=torch.device("cuda"),
+    )
+    mark_tied_parameters(model=nanotron_model, parallel_context=parallel_context)
+    return nanotron_model
+
+
+def _test_hf_to_nt(parallel_context, input_ids, model_name):
+    model_hf = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16).cuda()
+    model_nt = create_nanotron_model(parallel_context, get_nanotron_config(model_hf.config))
+    convert_hf_to_nt(model_hf, model_nt, model_hf.config)
+
+    position_ids = (
+        torch.arange(0, input_ids.shape[1], device=input_ids.device, dtype=torch.int32)
+        .unsqueeze(0)
+        .repeat(BATCH_SIZE, 1)
+    )
+    logits_nt = model_nt.model(input_ids, position_ids).view(BATCH_SIZE, SEQUENCE_LENGTH, -1)
+    logits_hf = model_hf(input_ids).logits.to(logits_nt.dtype)
+
+    # Detailed comparison
+    diff = (logits_hf - logits_nt).abs()
+    num_diff = (diff > ATOL).sum().item()
+    total = diff.numel()
+    print(f"\n=== Logits comparison ({model_name}) ===")
+    print(f"  Mean abs diff: {diff.mean().item():.6f}")
+    print(f"  Max abs diff:  {diff.max().item():.6f}")
+    print(f"  Elements > {ATOL}: {num_diff}/{total} ({100 * num_diff / total:.2f}%)")
+    argmax_match = (logits_hf.argmax(dim=-1) == logits_nt.argmax(dim=-1)).float().mean().item()
+    print(f"  Argmax match:  {argmax_match * 100:.1f}%")
+
+    if argmax_match == 1.0:
+        print("\nTEST PASSED: argmax matches perfectly")
+    else:
+        print(f"\nTEST RESULT: argmax match {argmax_match * 100:.1f}% — numerical diffs expected due to attention implementation differences")
+
+
+if __name__ == "__main__":
+    parallel_context = ParallelContext(data_parallel_size=1, pipeline_parallel_size=1, tensor_parallel_size=1)
+    input_ids = torch.randint(0, 128256, size=(BATCH_SIZE, SEQUENCE_LENGTH), device="cuda")
+    _test_hf_to_nt(parallel_context, input_ids, MODEL_NAME)


### PR DESCRIPTION
Adapt current conversion script from nouamane to support SmolLM3 transformers to nanotron conversion, the current script fails with `AttributeError: 'LlamaConfig' object has no attribute 'rope_interleaved'`. Changes:
- Add convert_hf_to_nanotron_qwen.py: use AutoModelForCausalLM and NanotronQwen2Config + warns on missing HF attrs with defaults, and saves both JSON and YAML configs
- Add no_rope_layer_interval -> no_rope_layer mapping in get_config_mapping()
- Add test_smollm3_conversion.py

```
=== Logits comparison (HuggingFaceTB/SmolLM3-3B-Base) ===
  Mean abs diff: 0.080078
  Max abs diff:  1.375000
  Elements > 0.03: 3054698/3847680 (79.39%)
  Argmax match:  93.3%

TEST RESULT: argmax match 93.3% 
```