### PR TITLE
Avoid shell in Weka warmup script

### DIFF
--- a/scripts/weka.py
+++ b/scripts/weka.py
@@ -111,8 +111,19 @@ def warmup_datasets(input_paths: Union[str, List[str]]) -> None:
             print(f"\nWarming up {folder_path}")
 
             # Use find to get all files and pipe to xargs for parallel fetching
-            cmd = f"find -L {folder_path} -type f | xargs -d '\\n' -r -n512 -P64 weka fs tier fetch"
-            subprocess.run(cmd, shell=True, check=True, text=True)
+            find_cmd = ["find", "-L", folder_path, "-type", "f"]
+            xargs_cmd = ["xargs", "-d", "\n", "-r", "-n512", "-P64", "weka", "fs", "tier", "fetch"]
+            find_process = subprocess.Popen(find_cmd, stdout=subprocess.PIPE, text=True)
+            try:
+                subprocess.run(xargs_cmd, stdin=find_process.stdout, check=True, text=True)
+            finally:
+                if find_process.stdout is not None:
+                    find_process.stdout.close()
+                find_returncode = find_process.wait()
+
+            if find_returncode:
+                raise subprocess.CalledProcessError(find_returncode, find_cmd)
+
             print(f"Finished warming up {folder_path}")
 
         except subprocess.CalledProcessError as e:

--- a/tests/test_weka_script.py
+++ b/tests/test_weka_script.py
@@ -1,0 +1,61 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def load_weka_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "scripts" / "weka.py"
+    spec = importlib.util.spec_from_file_location("weka_script", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeStdout:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeFindProcess:
+    def __init__(self):
+        self.stdout = FakeStdout()
+
+    def wait(self):
+        return 0
+
+
+def test_warmup_datasets_passes_paths_as_argv(monkeypatch):
+    weka = load_weka_module()
+    popen_calls = []
+    run_calls = []
+    find_process = FakeFindProcess()
+
+    def fake_popen(cmd, stdout, text):
+        popen_calls.append({"cmd": cmd, "stdout": stdout, "text": text})
+        return find_process
+
+    def fake_run(cmd, stdin, check, text):
+        run_calls.append({"cmd": cmd, "stdin": stdin, "check": check, "text": text})
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(weka.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(weka.subprocess, "run", fake_run)
+
+    folder_path = "/fsx/datasets/name; touch /tmp/should-not-run"
+    weka.warmup_datasets([folder_path])
+
+    assert popen_calls == [{"cmd": ["find", "-L", folder_path, "-type", "f"], "stdout": subprocess.PIPE, "text": True}]
+    assert run_calls == [
+        {
+            "cmd": ["xargs", "-d", "\n", "-r", "-n512", "-P64", "weka", "fs", "tier", "fetch"],
+            "stdin": find_process.stdout,
+            "check": True,
+            "text": True,
+        }
+    ]
+    assert find_process.stdout.closed


### PR DESCRIPTION
## Summary
- replace the Weka warmup shell pipeline with argv-based `find` and `xargs` subprocesses
- keep the existing parallel `xargs -P64` fetch behavior
- add a focused regression test showing dataset paths with shell metacharacters are passed as literal argv entries

## Testing
- `uv run --no-project --with pytest --with pytest-xdist pytest -q tests/test_weka_script.py -n 0`
- `uv run --no-project --with ruff ruff check scripts/weka.py tests/test_weka_script.py`
- `python3 -m py_compile scripts/weka.py tests/test_weka_script.py`
- `git diff --check`